### PR TITLE
Update the Denominator Exclusion Population name for VTE-1

### DIFF
--- a/pages/cql/VTE-1_FHIR-7.4.000.cql
+++ b/pages/cql/VTE-1_FHIR-7.4.000.cql
@@ -405,7 +405,7 @@ define "Encounter With Principal Procedure of SCIP VTE Selected Surgery":
 			such that SelectedProcedure.performed during FHIRHelpers.ToInterval( QualifyingEncounter.period)
 
 //Done
-define "Denominator Exclusions":
+define "Denominator Exclusion":
 	"Encounter Less Than 2 Days"
 		union "Encounter With ICU Location Stay 1 Day or More"
 		union "Encounter With Principal Diagnosis of Mental Disorder or Stroke"

--- a/pages/cql/VTE-1_FHIR-7.4.000.json
+++ b/pages/cql/VTE-1_FHIR-7.4.000.json
@@ -11255,7 +11255,7 @@
          }, {
             "localId" : "846",
             "locator" : "380:1-386:72",
-            "name" : "Denominator Exclusions",
+            "name" : "Denominator Exclusion",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
@@ -11263,7 +11263,7 @@
                "s" : {
                   "r" : "846",
                   "s" : [ {
-                     "value" : [ "define ","\"Denominator Exclusions\"",":\r\n\t" ]
+                     "value" : [ "define ","\"Denominator Exclusion\"",":\r\n\t" ]
                   }, {
                      "r" : "845",
                      "s" : [ {

--- a/pages/cql/VTE-1_FHIR-7.4.000.xml
+++ b/pages/cql/VTE-1_FHIR-7.4.000.xml
@@ -5468,10 +5468,10 @@
             </relationship>
          </expression>
       </def>
-      <def localId="846" locator="408:1-414:72" name="Denominator Exclusions" context="Patient" accessLevel="Public">
+      <def localId="846" locator="408:1-414:72" name="Denominator Exclusion" context="Patient" accessLevel="Public">
          <annotation xsi:type="a:Annotation">
             <a:s r="846">
-               <a:s>define &quot;Denominator Exclusions&quot;:&#xd;
+               <a:s>define &quot;Denominator Exclusion&quot;:&#xd;
 	</a:s>
                <a:s r="845">
                   <a:s r="843">


### PR DESCRIPTION
Renamed the CQL define from `Denominator Exclusions` to `Denominator Exclusion`, because 

* That's what `cqf-ruler` expects it to be called
* That's the pluralization used in the Measure population group valueset (see https://www.hl7.org/fhir/codesystem-measure-population.html#measure-population-denominator-exclusion)