### PR TITLE
Fix incorrect reference to text/cql.identifier

### DIFF
--- a/input/pages/measure-conformance.md
+++ b/input/pages/measure-conformance.md
@@ -1337,7 +1337,7 @@ Stratification is represented using the stratifier element. The semantics of thi
       "value": "stratifier-1-identifier"
     },
     "criteria": {
-      "language": "text/cql.identifier",
+      "language": "text/cql-identifier",
       "expression": "Stratification 1"
     }
   }
@@ -1380,7 +1380,7 @@ Part of the definition of a quality measure involves the ability to specify addi
       "text": "Supplemental Data"
     },
     "criteria": {
-      "language": "text/cql.identifier",
+      "language": "text/cql-identifier",
       "expression": "SDE Ethnicity"
     }
   }
@@ -1431,7 +1431,7 @@ Some measures may define variables used to adjust scores based on a measure of â
       "text": "Risk Adjustment Variable"
     },
     "criteria": {
-      "language": "text/cql.identifier",
+      "language": "text/cql-identifier",
       "expression": "Hepatic Failure"
     }
   }


### PR DESCRIPTION
Same as already done in https://jira.hl7.org/browse/FHIR-38787.

Not sure if I also should fix occurrences of `text/cql.identifier` in `exm-measure-bundle.json` and `sde-example-artifact-bundle.json`?