### PR TITLE
added group populations and criteria to output; added info to exm125 …

### DIFF
--- a/input/resources/measure-exm125-FHIR.json
+++ b/input/resources/measure-exm125-FHIR.json
@@ -715,7 +715,7 @@
       "description": "Females between 51 and 74 years of age who have a qualifying outpatient visit.",
       "criteria": {
         "language": "text/cql-identifier",
-        "expression": "Patient.gender = 'female'\n\t\t\t\tand Global.\"CalendarAgeInYearsAt\"(FHIRHelpers.ToDate(Patient.birthDate), start of \"Measurement Period\") in Interval[51, 74]\n\t\t\t\tand exists AdultOutpatientEncounters.\"Qualifying Encounters\""
+        "expression": "Initial Population"
       }
     }, {
       "code": {
@@ -728,7 +728,7 @@
       "description": "A mammogram exists within the last 27 months and the status of that was in 'final', 'amended', 'corrected', or 'appended'",
       "criteria": {
         "language": "text/cql-identifier",
-        "expression": "exists (\n\t\t\t\t[DiagnosticReport: \"Mammography\"] Mammogram\n\t\t\t\t\t\twhere ( Global.\"Normalize Interval\"(Mammogram.effective) ends 27 months or less before day of end of \"Measurement Period\" )\n\t\t\t\t\t\t\t\tand Mammogram.status in { 'final', 'amended', 'corrected', 'appended' }\n\t\t)"
+        "expression": "Numerator"
       }
     }, {
       "code": {
@@ -741,7 +741,7 @@
       "description": "Females between 51 and 74 years of age who have a qualifying outpatient visit.",
       "criteria": {
         "language": "text/cql-identifier",
-        "expression": "\"Initial Population\""
+        "expression": "Denominator"
       }
     }, {
       "code": {
@@ -754,7 +754,7 @@
       "description": "Patient is in Hospice care or has bilateral Mastectomies",
       "criteria": {
         "language": "text/cql-identifier",
-        "expression": "Hospice.\"Has Hospice\"\n\t\t\t\tor ( Count(\"Unilateral Mastectomy Procedure\") = 2 )\n\t\t\t\tor ( exists \"Right Mastectomy\" and exists \"Left Mastectomy\" )\n\t\t\t\tor exists \"History Bilateral Mastectomy\"\n\t\t\t\tor exists \"Bilateral Mastectomy Procedure\""
+        "expression": "Denominator Exclusion"
       }
     } ]
   } ],

--- a/input/resources/measure-exm125-FHIR.json
+++ b/input/resources/measure-exm125-FHIR.json
@@ -712,9 +712,10 @@
           "display": "Initial Population"
         } ]
       },
+      "description": "Females between 51 and 74 years of age who have a qualifying outpatient visit.",
       "criteria": {
         "language": "text/cql-identifier",
-        "expression": "Initial Population"
+        "expression": "Patient.gender = 'female'\n\t\t\t\tand Global.\"CalendarAgeInYearsAt\"(FHIRHelpers.ToDate(Patient.birthDate), start of \"Measurement Period\") in Interval[51, 74]\n\t\t\t\tand exists AdultOutpatientEncounters.\"Qualifying Encounters\""
       }
     }, {
       "code": {
@@ -724,9 +725,10 @@
           "display": "Numerator"
         } ]
       },
+      "description": "A mammogram exists within the last 27 months and the status of that was in 'final', 'amended', 'corrected', or 'appended'",
       "criteria": {
         "language": "text/cql-identifier",
-        "expression": "Numerator"
+        "expression": "exists (\n\t\t\t\t[DiagnosticReport: \"Mammography\"] Mammogram\n\t\t\t\t\t\twhere ( Global.\"Normalize Interval\"(Mammogram.effective) ends 27 months or less before day of end of \"Measurement Period\" )\n\t\t\t\t\t\t\t\tand Mammogram.status in { 'final', 'amended', 'corrected', 'appended' }\n\t\t)"
       }
     }, {
       "code": {
@@ -736,9 +738,10 @@
           "display": "Denominator"
         } ]
       },
+      "description": "Females between 51 and 74 years of age who have a qualifying outpatient visit.",
       "criteria": {
         "language": "text/cql-identifier",
-        "expression": "Denominator"
+        "expression": "\"Initial Population\""
       }
     }, {
       "code": {
@@ -748,9 +751,10 @@
           "display": "Denominator Exclusion"
         } ]
       },
+      "description": "Patient is in Hospice care or has bilateral Mastectomies",
       "criteria": {
         "language": "text/cql-identifier",
-        "expression": "Denominator Exclusion"
+        "expression": "Hospice.\"Has Hospice\"\n\t\t\t\tor ( Count(\"Unilateral Mastectomy Procedure\") = 2 )\n\t\t\t\tor ( exists \"Right Mastectomy\" and exists \"Left Mastectomy\" )\n\t\t\t\tor exists \"History Bilateral Mastectomy\"\n\t\t\t\tor exists \"Bilateral Mastectomy Procedure\""
       }
     } ]
   } ],

--- a/templates/liquid/Measure.liquid
+++ b/templates/liquid/Measure.liquid
@@ -321,30 +321,6 @@
                     </table>
                 </td>
             </tr>
-            <tr>
-                <th scope="row"><b>Population Criteria: </b></th>
-                <td style="padding-left: 4px;">
-                    <table class="grid-dict">
-                        <tr><th><b>Group</b></th><th><b>Population Criteria</b></th><th><b>Expression</b></th></tr>
-                        {% for group in Measure.group %}
-                        <tr>
-                            <td>{{group.id}}</td>
-                            {% for population in group.population %}
-                                <tr>
-                                    <td/>
-                                    <td>{{(population.code.first() as CodeableConcept).coding.first().display}}</td>
-                                    <td>
-                                        {% if population.criteria.expression%}
-                                            {{(population.criteria.expression)}}
-                                        {% endif %}
-                                    </td>
-                                 </tr>
-                            {% endfor %}
-                        </tr>
-                        {% endfor %}
-                    </table>
-                </td>
-            </tr>
         {% endif %}
         {% if Measure.supplementalData.exists() %}
             <tr>
@@ -585,32 +561,78 @@
         </tr>
         {% endif %}
         {% endfor %}
-        {% if Measure.extension.where(url = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition').exists() %}
-        <tr>
-          <th scope="row"><b>Logic Definitions: </b></th>
-          <td style="padding-left: 4px;">
-            {% for extension in Measure.extension.where(url = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition') %}
-                <table class="grid-dict">
-                    <tr><th><b>Library Name</b></th><th><b>Name</b></th><th><b>sequence</b></th></tr>
-                    <tr>
-                        {% for lNameExtension in extension.extension.where(url = 'libraryName') %}
-                            <td>{{lNameExtension.value}}</td>
+        {% if Measure.extension.where(url = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition').exists() or Measure.group.exists() %}
+            <tr>
+                <th scope="row"><b>Logic Definitions: </b></th>
+                <td style="padding-left: 4px;">
+                    {% if Measure.group.exists() %}
+                        <table class="grid-dict">
+                            <tr>
+                                <th><b>Group</b></th><th><b>Scoring</b></th><th><b>Population Criteria</b></th><th><b>Expression</b></th>
+                            </tr>
+                            <tr>
+                                {% for group in Measure.group %}
+                                    <td> {{  group.id }} </td>
+                                    <td>
+                                        {% if group.extension.where(url = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoring').exists() %}
+                                            <b>Group scoring:</b>
+                                            {% for extension in group.extension.where(url = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoring') %}
+                                               <span>  {{ extension.valueCodeableConcept.coding.code }} </span>
+                                            {% endfor %}
+                                        {% endif %}
+                                        {% if Measure.scoring.exists() %}
+                                            <b>Measure scoring:</b>
+                                            {% for coding in Measure.scoring.coding %}
+                                                {% if coding.code.exists() %}
+                                                    <p style="margin-bottom: 5px;">
+                                                        <span>{{ coding.code }}</span>
+                                                    </p>
+                                                {% endif %}
+                                                {% if coding.exists().not and coding.display.exists() %}
+                                                   <span>{{ coding.display }}</span>
+                                                {% endif %}
+                                            {% endfor %}
+                                        {% endif %}
+                                    </td>
+                                    {% for population in group.population %}
+                                        <tr>
+                                            <td/>
+                                            <td/>
+                                            <td>{{ (population.code.first() as CodeableConcept).coding.first().display }}</td>
+                                            <td>
+                                                {% if population.criteria.expression %}
+                                                    {{ (population.criteria.expression) }}
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+
+                            {%  endfor %}
+                            </tr>
+                        </table>
+                    {% endif %}
+                    {% for extension in Measure.extension.where(url = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition') %}
+                        <table class="grid-dict">
+                            <tr><th><b>Library Name</b></th><th><b>Name</b></th><th><b>sequence</b></th></tr>
+                            <tr>
+                                {% for lNameExtension in extension.extension.where(url = 'libraryName') %}
+                                    <td>{{lNameExtension.value}}</td>
+                                {% endfor %}
+                                {% for nameExtension in extension.extension.where(url = 'name') %}
+                                    <td>{{nameExtension.value}}</td>
+                                {% endfor %}
+                                {% for sequenceExtension in extension.extension.where(url = 'sequence') %}
+                                    <td>{{sequenceExtension.value}}</td>
+                                {% endfor %}
+                            </tr>
+                        </table>
+                        {% for statementExtension in extension.extension.where(url = 'statement') %}
+                            <pre><code class="language-cql">{{statementExtension.value.escape('html')}}</code></pre>
                         {% endfor %}
-                        {% for nameExtension in extension.extension.where(url = 'name') %}
-                            <td>{{nameExtension.value}}</td>
-                        {% endfor %}
-                        {% for sequenceExtension in extension.extension.where(url = 'sequence') %}
-                            <td>{{sequenceExtension.value}}</td>
-                        {% endfor %}
-                    </tr>
-                </table>
-                {% for statementExtension in extension.extension.where(url = 'statement') %}
-                    <pre><code class="language-cql">{{statementExtension.value.escape('html')}}</code></pre>
-                {% endfor %}
-                <br/><br/>
-            {% endfor %}
-          </td>
-        </tr>
+                        <br/><br/>
+                    {% endfor %}
+                </td>
+            </tr>
         {% endif %}
     </table>
 </div>

--- a/templates/liquid/Measure.liquid
+++ b/templates/liquid/Measure.liquid
@@ -296,6 +296,56 @@
           </td>
         </tr>
         {% endif %}
+        {% if Measure.group.exists() %}
+            <tr>
+                <th scope="row"><b>Populations: </b></th>
+                <td style="padding-left: 4px;">
+                    <table class="grid-dict">
+                        <tr><th><b>Group</b></th><th><b>Population</b></th><th><b>Description</b></th></tr>
+                        {% for group in Measure.group %}
+                        <tr>
+                            <td>{{group.id}}</td>
+                            {% for population in group.population %}
+                                <tr>
+                                    <td/>
+                                    <td>{{(population.code.first() as CodeableConcept).coding.first().display}}</td>
+                                    <td>
+                                        {% if population.description %}
+                                            {{(population.description)}}
+                                        {% endif %}
+                                    </td>
+                                 </tr>
+                            {% endfor %}
+                        </tr>
+                        {% endfor %}
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><b>Population Criteria: </b></th>
+                <td style="padding-left: 4px;">
+                    <table class="grid-dict">
+                        <tr><th><b>Group</b></th><th><b>Population Criteria</b></th><th><b>Expression</b></th></tr>
+                        {% for group in Measure.group %}
+                        <tr>
+                            <td>{{group.id}}</td>
+                            {% for population in group.population %}
+                                <tr>
+                                    <td/>
+                                    <td>{{(population.code.first() as CodeableConcept).coding.first().display}}</td>
+                                    <td>
+                                        {% if population.criteria.expression%}
+                                            {{(population.criteria.expression)}}
+                                        {% endif %}
+                                    </td>
+                                 </tr>
+                            {% endfor %}
+                        </tr>
+                        {% endfor %}
+                    </table>
+                </td>
+            </tr>
+        {% endif %}
         {% if Measure.supplementalData.exists() %}
             <tr>
                 <th scope="row"><b>Supplemental Data: </b></th>

--- a/templates/liquid/Measure.liquid
+++ b/templates/liquid/Measure.liquid
@@ -601,7 +601,7 @@
                                             <td>{{ (population.code.first() as CodeableConcept).coding.first().display }}</td>
                                             <td>
                                                 {% if population.criteria.expression %}
-                                                    {{ (population.criteria.expression) }}
+                                                <pre><code class="language-cql">{{ (population.criteria.expression.escape('html')) }}</code></pre>
                                                 {% endif %}
                                             </td>
                                         </tr>


### PR DESCRIPTION
…as examples
This PR covers the first 2 items on the issue https://jira.hl7.org/browse/FHIR-40237
1. Add population descriptions to metadata table
2. Add population criteria grouping for primary population criteria

Changes were made to measure-exm125-FHIR based on information in the corresponding cql to allow this information to be displayed.