### PR TITLE
FHIR-40697, FHIR-40684, FHIR-39726, FHIR-40241

### DIFF
--- a/input/data/package-list.yml
+++ b/input/data/package-list.yml
@@ -40,3 +40,4 @@ list:
       1. **Applied**: Add ballot note to consider alternative approach to composite measure calculation ([FHIR-32599](https://jira.hl7.org/browse/FHIR-32599))
       1. **Applied**: Added a draft operation and clarified behavior of child artifacts in repository operations ([FHIR-39489](https://jira.hl7.org/browse/FHIR-32599))
       1. **Applied**: Relaxed cardinality in extension for 'cqfm-type' to 0..* from 0..1.  ([FHIR-40697](https://jira.hl7.org/browse/FHIR-40697))
+      1. **Applied**: Relaxed introduction statement about QI Core  ([FHIR-40684]{https://jira.hl7.org/browse/FHIR-40684))

--- a/input/data/package-list.yml
+++ b/input/data/package-list.yml
@@ -41,4 +41,5 @@ list:
       1. **Applied**: Added a draft operation and clarified behavior of child artifacts in repository operations ([FHIR-39489](https://jira.hl7.org/browse/FHIR-32599))
       1. **Applied**: Relaxed cardinality in Computable measure cqfm extension for 'cqfm-type' to 0..* from 0..1.  ([FHIR-40697](https://jira.hl7.org/browse/FHIR-40697))
       1. **Applied**: Relaxed introduction statement about QI Core  ([FHIR-40684](https://jira.hl7.org/browse/FHIR-40684))
-      1. **Applied**: Fixed linnk for Colorectal Cancer Screening example  ([FHIR-39726](https://jira.hl7.org/browse/FHIR-39726))
+      1. **Applied**: Fixed link for Colorectal Cancer Screening example  ([FHIR-39726](https://jira.hl7.org/browse/FHIR-39726))
+      1. **Applied**: Clarified definition wording for usage element of Publishable Measure CQFM  ([FHIR-40241](https://jira.hl7.org/browse/FHIR-40241))

--- a/input/data/package-list.yml
+++ b/input/data/package-list.yml
@@ -39,3 +39,4 @@ list:
       1. **Applied**: Snippet and link mismatch related to Supplemental Data Elements ([FHIR-37548](https://jira.hl7.org/browse/FHIR-37548))
       1. **Applied**: Add ballot note to consider alternative approach to composite measure calculation ([FHIR-32599](https://jira.hl7.org/browse/FHIR-32599))
       1. **Applied**: Added a draft operation and clarified behavior of child artifacts in repository operations ([FHIR-39489](https://jira.hl7.org/browse/FHIR-32599))
+      1. **Applied**: Relaxed cardinality in extension for 'cqfm-type' to 0..* from 0..1.  ([FHIR-40697](https://jira.hl7.org/browse/FHIR-40697))

--- a/input/data/package-list.yml
+++ b/input/data/package-list.yml
@@ -39,5 +39,6 @@ list:
       1. **Applied**: Snippet and link mismatch related to Supplemental Data Elements ([FHIR-37548](https://jira.hl7.org/browse/FHIR-37548))
       1. **Applied**: Add ballot note to consider alternative approach to composite measure calculation ([FHIR-32599](https://jira.hl7.org/browse/FHIR-32599))
       1. **Applied**: Added a draft operation and clarified behavior of child artifacts in repository operations ([FHIR-39489](https://jira.hl7.org/browse/FHIR-32599))
-      1. **Applied**: Relaxed cardinality in extension for 'cqfm-type' to 0..* from 0..1.  ([FHIR-40697](https://jira.hl7.org/browse/FHIR-40697))
-      1. **Applied**: Relaxed introduction statement about QI Core  ([FHIR-40684]{https://jira.hl7.org/browse/FHIR-40684))
+      1. **Applied**: Relaxed cardinality in Computable measure cqfm extension for 'cqfm-type' to 0..* from 0..1.  ([FHIR-40697](https://jira.hl7.org/browse/FHIR-40697))
+      1. **Applied**: Relaxed introduction statement about QI Core  ([FHIR-40684](https://jira.hl7.org/browse/FHIR-40684))
+      1. **Applied**: Fixed linnk for Colorectal Cancer Screening example  ([FHIR-39726](https://jira.hl7.org/browse/FHIR-39726))

--- a/input/pages/changes.md
+++ b/input/pages/changes.md
@@ -25,6 +25,7 @@ This page details changes made in each version of the Quality Measure IG
 * **Applied**: Add requirements to support maintenance of a quality program([FHIR-37506](https://jira.hl7.org/browse/FHIR-37506))
 * **Applied**: Fix incorrect reference to text/cql.identifier([FHIR-38787](https://jira.hl7.org/browse/FHIR-38787))
 * **Applied**: Snippet and link mismatch related to Supplemental Data Elements([FHIR-37548](https://jira.hl7.org/browse/FHIR-37548))
+* **Applied**: Relaxed cardinality in extension for 'cqfm-type' to 0..* from 0..1.  ([FHIR-40697](https://jira.hl7.org/browse/FHIR-40697))
 
 ### STU3 Release for FHIR R4 (v3.0.0)
 

--- a/input/pages/changes.md
+++ b/input/pages/changes.md
@@ -28,6 +28,7 @@ This page details changes made in each version of the Quality Measure IG
 * **Applied**: Relaxed cardinality in Computable measure cqfm extension for 'cqfm-type' to 0..* from 0..1.  ([FHIR-40697](https://jira.hl7.org/browse/FHIR-40697))
 * **Applied**: Relaxed introduction statement about QI Core  ([FHIR-40684](https://jira.hl7.org/browse/FHIR-40684))
 * **Applied**: Fixed link for Colorectal Cancer Screening example  ([FHIR-39726](https://jira.hl7.org/browse/FHIR-39726))
+* **Applied**: Clarified definition wording for usage element of Publishable Measure CQFM  ([FHIR-40241](https://jira.hl7.org/browse/FHIR-40241))
 
 ### STU3 Release for FHIR R4 (v3.0.0)
 

--- a/input/pages/changes.md
+++ b/input/pages/changes.md
@@ -25,8 +25,9 @@ This page details changes made in each version of the Quality Measure IG
 * **Applied**: Add requirements to support maintenance of a quality program([FHIR-37506](https://jira.hl7.org/browse/FHIR-37506))
 * **Applied**: Fix incorrect reference to text/cql.identifier([FHIR-38787](https://jira.hl7.org/browse/FHIR-38787))
 * **Applied**: Snippet and link mismatch related to Supplemental Data Elements([FHIR-37548](https://jira.hl7.org/browse/FHIR-37548))
-* **Applied**: Relaxed cardinality in extension for 'cqfm-type' to 0..* from 0..1.  ([FHIR-40697](https://jira.hl7.org/browse/FHIR-40697))
-* **Applied**: Relaxed introduction statement about QI Core  ([FHIR-40684]{https://jira.hl7.org/browse/FHIR-40684))
+* **Applied**: Relaxed cardinality in Computable measure cqfm extension for 'cqfm-type' to 0..* from 0..1.  ([FHIR-40697](https://jira.hl7.org/browse/FHIR-40697))
+* **Applied**: Relaxed introduction statement about QI Core  ([FHIR-40684](https://jira.hl7.org/browse/FHIR-40684))
+* **Applied**: Fixed link for Colorectal Cancer Screening example  ([FHIR-39726](https://jira.hl7.org/browse/FHIR-39726))
 
 ### STU3 Release for FHIR R4 (v3.0.0)
 

--- a/input/pages/changes.md
+++ b/input/pages/changes.md
@@ -26,6 +26,7 @@ This page details changes made in each version of the Quality Measure IG
 * **Applied**: Fix incorrect reference to text/cql.identifier([FHIR-38787](https://jira.hl7.org/browse/FHIR-38787))
 * **Applied**: Snippet and link mismatch related to Supplemental Data Elements([FHIR-37548](https://jira.hl7.org/browse/FHIR-37548))
 * **Applied**: Relaxed cardinality in extension for 'cqfm-type' to 0..* from 0..1.  ([FHIR-40697](https://jira.hl7.org/browse/FHIR-40697))
+* **Applied**: Relaxed introduction statement about QI Core  ([FHIR-40684]{https://jira.hl7.org/browse/FHIR-40684))
 
 ### STU3 Release for FHIR R4 (v3.0.0)
 

--- a/input/pages/examples.md
+++ b/input/pages/examples.md
@@ -36,7 +36,7 @@ These examples illustrate patient-based screening measures
 This section provides examples of all four composite measure scoring methods described by this implementation guide. Each composite is constructed using the same five component measures:
 
 * [Breast Cancer Screening (BCS)](Measure-BCSComponent.html) - Patient-based proportion measure
-* [Colorectal Cancer Screening (CCS)](Measure-CCSComponent.html) - Patient-based proportion measure
+* [Colorectal Cancer Screening (CCS)](Measure-measure-exm130-FHIR.html) - Patient-based proportion measure
 * [High Blood Pressure Screening (HBP)](Measure-HBPComponent.html) - Encounter-based proportion measure
 * [Pneumococcal Vaccination (PVS)](Measure-PVSComponent.html) - Patient-based proportion measure
 * [Tobacco Screening (TSC)](Measure-TSCComponent.html) - Patient-based proportion measure

--- a/input/pages/introduction.md
+++ b/input/pages/introduction.md
@@ -11,7 +11,7 @@
 * [Clinical Quality Language (CQL) R1.4](https://cql.hl7.org/)
 * [QI-Core Implementation Guide (QI-Core) R4.1](http://hl7.org/fhir/us/qicore/)
 
-To avoid variation in the use of FHIR Resources and metadata across eCQMs and clinical decision support (CDS), a quality-related implementation guide based on a logical data model is essential. In the US Realm, eCQMs SHALL use [FHIR Quality Improvement Core (QICore)](http://hl7.org/fhir/us/qicore) profiles as the data model to maintain consistency.
+To avoid variation in the use of FHIR Resources and metadata across eCQMs and clinical decision support (CDS), a quality-related implementation guide based on a logical data model is essential. In the US Realm, eCQMs should use [FHIR Quality Improvement Core (QICore)](http://hl7.org/fhir/us/qicore) profiles as the data model to maintain consistency. Other FHIR based data models are also acceptable for use.
 
 Although the specification is based on the 1.4 version of CQL, backwards-compatible future versions of CQL can be used as well. In addition, if necessary, the 1.2 and 1.3 versions of CQL can be used without loss of functionality for this Implementation Guide.
 

--- a/input/profiles/StructureDefinition-computable-measure-cqfm.json
+++ b/input/profiles/StructureDefinition-computable-measure-cqfm.json
@@ -451,7 +451,7 @@
         "path": "Measure.group.extension",
         "sliceName": "type",
         "min": 0,
-        "max": "1",
+        "max": "*", 
         "type": [
           {
             "code": "Extension",

--- a/input/profiles/StructureDefinition-publishable-measure-cqfm.json
+++ b/input/profiles/StructureDefinition-publishable-measure-cqfm.json
@@ -895,7 +895,15 @@
           }
         ],
         "mustSupport": false
+      },
+      {
+        "id": "Measure.guidance",
+        "path": "Measure.guidance",
+        "min": 0,
+        "max": "0",
+        "mustSupport": false
       }
+
     ]
   }
 }

--- a/input/profiles/StructureDefinition-publishable-measure-cqfm.json
+++ b/input/profiles/StructureDefinition-publishable-measure-cqfm.json
@@ -546,6 +546,7 @@
       {
         "id": "Measure.usage",
         "path": "Measure.usage",
+        "short": "Allows measure developers to provide additional guidance so that implementers can more easily interpret and implement components of the measure.",
         "requirements": "A published measure should provide clinical usage notes for the measure.",
         "mustSupport": true
       },


### PR DESCRIPTION
https://jira.hl7.org/browse/FHIR-40697 
    Relaxed cardinality in Computable measure cqfm extension for 'cqfm-type' to 0..* from 0..1

https://jira.hl7.org/browse/FHIR-40684
    Relaxed introduction statement about QI Core

https://jira.hl7.org/browse/FHIR-39726
   Fixed link for Colorectal Cancer Screening example on examples page

https://jira.hl7.org/browse/FHIR-40241
   Clarified definition wording for usage element of Publishable Measure CQFM
   Note that this ticket also called for setting cardinality of 'guidance' to 0..0 as it was to be removed.  Apparently, that removal has already happened  (See resolved/published ticket https://jira.hl7.org/browse/FHIR-39605 )