### PR TITLE
FHIR-40105: double quotes rendering issues in CQL libraries

### DIFF
--- a/templates/liquid/Library.liquid
+++ b/templates/liquid/Library.liquid
@@ -374,7 +374,19 @@
           <td colspan="2">
             <table>
               <tr><th><a id="cql-content"><b>Content: </b></a> {{c.contentType}}</th></tr>
-              <tr><td><pre><code class="language-cql">{{c.data.decode('base64').escape('html')}}</code></pre></td></tr>
+              <tr><td><pre><code class="language-cql" id="code-block">
+              
+              <script>  
+                document.addEventListener('DOMContentLoaded', function() {
+                var element = document.getElementById('code-block');
+                  var decodedString = atob('{{c.data}}');
+                  element.innerHTML = decodedString;
+                  console.log(decodedString);
+                });
+
+              </script>
+
+              </code></pre></td></tr>
             </table>
           </td>
         </tr>
@@ -392,3 +404,4 @@
         {% endfor %}
     </table>
 </div>
+                

--- a/templates/liquid/Library.liquid
+++ b/templates/liquid/Library.liquid
@@ -381,7 +381,6 @@
                 var element = document.getElementById('code-block');
                   var decodedString = atob('{{c.data}}');
                   element.innerHTML = decodedString;
-                  console.log(decodedString);
                 });
 
               </script>


### PR DESCRIPTION
I modified the Library.liquid file to decode the base64 string used in the cql code section 'on the fly' using javascript's atob. The built in native decode of Liquid introduced escape character issues.

https://jira.hl7.org/browse/FHIR-40105

