### PR TITLE
FHIR-40210

### DIFF
--- a/input/pages/downloads.md
+++ b/input/pages/downloads.md
@@ -9,6 +9,13 @@ The following file contains the complete, downloadable implementation guide:
 
 -  [Full IG](full-ig.zip)
 
+### IG Package
+{: #package}
+
+The following file is the FHIR IG Package [NPM Subset](https://confluence.hl7.org/display/FHIR/NPM+Package+Specification)
+
+- [package.tgz](package.tgz)
+
 ### Definitions
 {: #definitions}
 

--- a/input/pages/measure-terminology-service.md
+++ b/input/pages/measure-terminology-service.md
@@ -40,6 +40,22 @@ Because this capability results in the potential for parameter values to be supp
 #### Quality Programs
 To support organization of releases, the Quality Program profile can also be used to define quality programs that contain multiple releases over multiple years. This usage is represented by an overall Quality Program that is then referenced by each release using the [partOf](StructureDefinition-cqfm-partOf.html) extension.
 
+#### Discovery of Expansion Identifiers
+
+To discover what values of the $expand `expansion` parameter are supported by the Measure Terminology Service, start with a Library search using the `_profile` parameter to limit the search to CQFM Quality Programs, and the `contained-parameter-name` search parameter with the value `expansion`.
+
+If Library.contained.parameter.name matches the contained-parameter-name search parameter, then return this Library in the searchset.
+
+For example, [base]/Library?_profile=http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/quality-program-cqfm&contained-parameter-name=expansion
+
+That example searches for CQFM Quality Program Library resources that have Library.contained.parameter.name equal to the string "expansion". The corresponding Library.contained.parameter.valueUri is the expansion identifier, which can be substituted for "xxx" in [base]/Valueset/[id]/$expand?expansion=xxx .
+
+To discover what value sets are associated with an expansion named "xxx", you need to search for a Library with the CQF Quality Program profile and expansion-identifier equal to "xxx"
+
+[base]/Library?_profile=http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/quality-program-cqfm&expansion-name=xxx
+
+The Library resource(s) that match have the canonical for the value sets listed in Library.relatedArtifact.resource with relatedArtifact.type equal to "depends-on".
+
 #### Hosted Content
 Terminology services may act as a repository for content that is managed and created elsewhere (i.e. hosted content AKA a convenience copy), or they may provide features to author and manage content directly, or any combination. When hosting content that is managed elsewhere, the service must ensure that the content of the resource is materially the same (i.e. the values for all elements are the same where those elements are specified in the Shareable and Publishable profiles) as the source of truth.
 In particular, for systems that provide both management and hosting of externally managed content, the status element for hosted content SHALL be the same as the status of the content in the source of truth.

--- a/input/pages/measure-terminology-service.md
+++ b/input/pages/measure-terminology-service.md
@@ -40,21 +40,8 @@ Because this capability results in the potential for parameter values to be supp
 #### Quality Programs
 To support organization of releases, the Quality Program profile can also be used to define quality programs that contain multiple releases over multiple years. This usage is represented by an overall Quality Program that is then referenced by each release using the [partOf](StructureDefinition-cqfm-partOf.html) extension.
 
-#### Discovery of Expansion Identifiers
 
-To discover what values of the $expand `expansion` parameter are supported by the Measure Terminology Service, start with a Library search using the `_profile` parameter to limit the search to CQFM Quality Programs, and the `contained-parameter-name` search parameter with the value `expansion`.
 
-If Library.contained.parameter.name matches the contained-parameter-name search parameter, then return this Library in the searchset.
-
-For example, [base]/Library?_profile=http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/quality-program-cqfm&contained-parameter-name=expansion
-
-That example searches for CQFM Quality Program Library resources that have Library.contained.parameter.name equal to the string "expansion". The corresponding Library.contained.parameter.valueUri is the expansion identifier, which can be substituted for "xxx" in [base]/Valueset/[id]/$expand?expansion=xxx .
-
-To discover what value sets are associated with an expansion named "xxx", you need to search for a Library with the CQF Quality Program profile and expansion-identifier equal to "xxx"
-
-[base]/Library?_profile=http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/quality-program-cqfm&expansion-name=xxx
-
-The Library resource(s) that match have the canonical for the value sets listed in Library.relatedArtifact.resource with relatedArtifact.type equal to "depends-on".
 
 #### Hosted Content
 Terminology services may act as a repository for content that is managed and created elsewhere (i.e. hosted content AKA a convenience copy), or they may provide features to author and manage content directly, or any combination. When hosting content that is managed elsewhere, the service must ensure that the content of the resource is materially the same (i.e. the values for all elements are the same where those elements are specified in the Shareable and Publishable profiles) as the source of truth.
@@ -202,6 +189,8 @@ Note that when a code system authority has not established a versioning system, 
     8. composed-of: Returning any quality program that includes the given measure canonical or quality program version manifest or release
     9. depends-on: Returning any quality program that references the given code system or value set canonical
     10. part-of: Returning any version manifest or release that is part of the given quality program
+    11. contained-parameter-name: Returning any quality program having the given value in the Library.contained.parameter.name
+    12. expansion-identifier: Returning any quality program having the the given value in the Library.contained.parameter.valueUri 
 
 5. SHALL support specifying expansion rules for the following $expand parameters
     1. SHALL support the activeOnly parameter
@@ -510,10 +499,22 @@ The following example illustrates a program release that is an _active_ instance
 Specifically, the program release uses the `expansion` parameter in the contained expansion parameters at the artifact collection level to indicate that all value sets used with artifacts in the program should expand using this expansion identifier:
 
 ```
-{
-  "name": "expansion",
-  "valueUri": "eCQM%20Update%202020-05-07"
-}
+"contained": [
+    {
+      "resourceType": "Parameters",
+      "id": "exp-params",
+      "parameter": [
+        {
+          "name" : "system-version",
+          "valueUri" : "http://snomed.info/sct|http://snomed.info/sct/731000124108/version/20190901"
+        },
+        {
+          "name": "expansion",
+          "valueUri": "eCQM%20Update%202020-05-07"
+        }
+      ]
+    }
+  ]
 ```
 
 In addition, the program release specifies versions of code systems, value sets, and measures included in the release:
@@ -554,6 +555,26 @@ In addition, the program release specifies versions of code systems, value sets,
 The full example is available here:
 
 * [eCQM Release, 2020-05-07](Library-ecqm-update-2020-05-07.html)
+
+#### Discovery of Expansion Identifiers
+
+To discover what values of the $expand `expansion` parameter are supported by the Measure Terminology Service, start with a Library search using the `_profile` parameter to limit the search to [CQFMQualityProgram](StructureDefinition-quality-program-cqfm.html), and the `contained-parameter-name` search parameter with the value `expansion`.
+
+If Library.contained.parameter.name matches the contained-parameter-name search parameter, then return this Library in the searchset.
+
+For example, [base]/Library?_profile=http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/quality-program-cqfm&contained-parameter-name=expansion
+
+That example searches for CQFM Quality Program Library resources that have Library.contained.parameter.name equal to the string `expansion`. The corresponding Library.contained.parameter.valueUri is the expansion identifier, which can be used in a ValueSet $expand. If the previous Library search found a ValurUri with "eCQM%20Update%202020-05-07", then use it in the `expansion` parameter:  [base]/Valueset/[id]/$expand?expansion=eCQM%20Update%202020-05-07 
+
+To discover what value sets are associated with an expansion named "xxx", you can search for a Library with the [CQFMQualityProgram](StructureDefinition-quality-program-cqfm.html) profile and `expansion-identifier` equal to "eCQM%20Update%202020-05-07"
+
+[base]/Library?_profile=http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/quality-program-cqfm&expansion-name=eCQM%20Update%202020-05-07
+
+The Library resource(s) that match have the canonical for the value sets listed in Library.relatedArtifact.resource with relatedArtifact.type equal to "depends-on".
+
+Another way is to use the expansion identifier (`eCQM%20Update%202020-05-07` in this example) in a ValueSet search
+
+[base]/ValueSet?expansion=eCQM%20Update%202020-05-07
 
 ##### Expansion with manifests and releases:
 

--- a/input/pages/measure-terminology-service.md
+++ b/input/pages/measure-terminology-service.md
@@ -36,6 +36,7 @@ Because this capability results in the potential for parameter values to be supp
 2. If a ValueSet dependency is specified as part of the version manifest (and no version for the value set is specified in the artifact reference), the version has the same meaning as the `valueSetVersion` parameter to the $expand
 3. If a CodeSystem dependency is specified as part of the version manifest (and no version for the code system is specified in the artifact reference), the version has the same meaning as the `system-version` parameter to the $expand
 4. Version information specified in the expansion parameters takes precedence over version information specified as part of the version manifest (i.e. as a relatedArtifact dependency in the artifact collection library)
+5. When processing an expand (or any artifact operation that will encounter canonical references), when an un-versioned canonical reference is encountered, the manifest is consulted to determine a version of the artifact to be used for that reference.
 
 #### Quality Programs
 To support organization of releases, the Quality Program profile can also be used to define quality programs that contain multiple releases over multiple years. This usage is represented by an overall Quality Program that is then referenced by each release using the [partOf](StructureDefinition-cqfm-partOf.html) extension.
@@ -130,17 +131,18 @@ Note that when a code system authority has not established a versioning system, 
     9. keyword: Returning any valueset that has a valueset-keyword extension  matching the given keyword
 
 9. SHOULD support ValueSet searches by:
-    1. expansion: Used in combination with url or identifier (and optionally version), returning a ValueSet instance with the given expansion identifier.
-    2. context: Returning all artifacts with a use context value matching the given context
-    3. context-type: Returning all artifacts with a use context type matching the given context type
-    4. context-type-quantity: Returning all artifacts with a use context quantity or range matching the given quantity
-    5. context-type-value: Returning all artifacts with a given use context type and value
-    6. codesystem: Returning any valueset that directly references the given codesystem url (optionally versioned)
-    7. valueset: Returning any valueset that references or is referenced by the given valueset url (optionally versioned)
-    8. library: Returning any valueset that is referenced by the given library url (optionally versioned)
-    9. measure: Returning any valueset that is referenced by the given measure url (optionally versioned)
-    10. artifact: Returning any valueset that directly or indirectly references or is referenced by the given artifact url (optionally versioned)
-    11. servers SHOULD support the _text and _content search parameters (as described in the base spec here https://hl7.org/fhir/search.html#text) 
+    1. context: Returning all artifacts with a use context value matching the given context
+    2. context-type: Returning all artifacts with a use context type matching the given context type
+    3. context-type-quantity: Returning all artifacts with a use context quantity or range matching the given quantity
+    4. context-type-value: Returning all artifacts with a given use context type and value
+    5. codesystem: Returning any valueset that directly references the given codesystem url (optionally versioned)
+    6. valueset: Returning any valueset that references or is referenced by the given valueset url (optionally versioned)
+    7. library: Returning any valueset that is referenced by the given library url (optionally versioned)
+    8. measure: Returning any valueset that is referenced by the given measure url (optionally versioned)
+    9. artifact: Returning any valueset that directly or indirectly references or is referenced by the given artifact url (optionally versioned)
+    10. servers SHOULD support the _text and _content search parameters (as described in the base spec here https://hl7.org/fhir/search.html#text) 
+    11. expansion: MAY support returning any ValueSet instance with the given expansion identifier. May be used in combination with url or identifier
+
 
 10. SHALL Support [ValueSet/$validate-code](http://hl7.org/fhir/R4/valueset-operation-validate-code.html)
     1. SHALL support the url parameter
@@ -163,12 +165,15 @@ Note that when a code system authority has not established a versioning system, 
     7. SHALL support the system-version parameter
     8. SHALL support the check-system-version parameter
     9. SHALL support the force-system-version parameter
-    10. SHOULD support includeDesignation parameter
-    11. SHOULD support designation parameter
-    12. SHOULD support paging parameters
-    13. SHOULD support the `manifest` parameter (defined in the [cqfm-valueset-expand](OperationDefinition-ValueSet-expand.html))
-    14. SHOULD support the `expansion` parameter (defined in the [cqfm-valueset-expand](OperationDefinition-ValueSet-expand.html))
-    15. SHOULD support the `includeDraft` parameter (defined in the [cqfm-valueset-expand](OperationDefinition-ValueSet-expand.html))
+    10. SHALL support the canonicalVersion parameter (defined in the [cqfm-valueset-expand](OperationDefinition-ValueSet-expand.html))
+    11. SHALL support the forceCanonicalVersion parameter (defined in the [cqfm-valueset-expand](OperationDefinition-ValueSet-expand.html))
+    12. SHALL support the checkCanonicalVersion parameter (defined in the [cqfm-valueset-expand](OperationDefinition-ValueSet-expand.html))
+    13. MAY support the `expansion` parameter (defined in the [cqfm-valueset-expand](OperationDefinition-ValueSet-expand.html))
+    14. SHOULD support includeDesignation parameter
+    15. SHOULD support designation parameter
+    16. SHOULD support paging parameters
+    17. SHOULD support the `manifest` parameter (defined in the [cqfm-valueset-expand](OperationDefinition-ValueSet-expand.html))
+    18. SHOULD support the `includeDraft` parameter (defined in the [cqfm-valueset-expand](OperationDefinition-ValueSet-expand.html))
 
 ### Quality Programs (Artifact Collections)
 
@@ -189,17 +194,18 @@ Note that when a code system authority has not established a versioning system, 
     8. composed-of: Returning any quality program that includes the given measure canonical or quality program version manifest or release
     9. depends-on: Returning any quality program that references the given code system or value set canonical
     10. part-of: Returning any version manifest or release that is part of the given quality program
-    11. contained-parameter-name: Returning any quality program having the given value in the Library.contained.parameter.name
-    12. expansion-identifier: Returning any quality program having the the given value in the Library.contained.parameter.valueUri 
+    11. contained-parameter-name: MAY support returning any quality program having the given value in the Library.contained.parameter.name
+    12. expansion-identifier: MAY support returning any quality program having the the given value in the Library.contained.parameter.valueUri 
 
 5. SHALL support specifying expansion rules for the following $expand parameters
     1. SHALL support the activeOnly parameter
     2. SHALL support the system-version parameter
     3. SHALL support the check-system-version parameter
     4. SHALL support the force-system-version parameter
-    5. SHOULD support other parameters
-    6. SHOULD support the `expansion` parameter (defined in the [cqfm-valueset-expand](OperationDefinition-ValueSet-expand.html))
-    7. SHOULD support the `includeDraft` parameter (defined in the [cqfm-valueset-expand](OperationDefinition-ValueSet-expand.html))
+    5. SHALL support the valueSetVersion parameter
+    6. MAY support the `expansion` parameter (defined in the [cqfm-valueset-expand](OperationDefinition-ValueSet-expand.html))
+    7. SHOULD support other parameters
+    8. SHOULD support the `includeDraft` parameter (defined in the [cqfm-valueset-expand](OperationDefinition-ValueSet-expand.html))
 
 6. Because this capability results in the potential for parameter values to be supplied in multiple places, the following rules apply:
     1. If a parameter is specified as part of the $expand operation directly, it takes precedence
@@ -267,6 +273,7 @@ The `compose` element of this value set is:
 
 ```
 "compose": {
+  "inactive": true,
   "include": [
     {
       "system": "http://snomed.info/sct",
@@ -372,7 +379,7 @@ The expected [result](ValueSet-chronic-liver-disease-legacy-example-current-acti
 }
 ```
 
-The result of the `activeOnly` parameter is to exclude the inactive code, even
+The result of the `activeOnly` parameter set to `true` is to exclude the inactive code, even
 though it was explicitly included in the value set definition.
 
 ##### Version-specific expand
@@ -572,15 +579,15 @@ That example searches for CQFM Quality Program Library resources that have Libra
 [base]/Valueset/[id]/$expand?expansion=eCQM%20Update%202020-05-07
 ```
 
-To discover what value sets are associated with an expansion named `eCQM%20Update%202020-05-07`, you can search for a Library with the [CQFMQualityProgram](StructureDefinition-quality-program-cqfm.html) profile and `expansion-identifier` equal to `eCQM%20Update%202020-05-07`
+To discover what value sets are associated with an expansion identifier `eCQM%20Update%202020-05-07`, you can search for a Library with the [CQFMQualityProgram](StructureDefinition-quality-program-cqfm.html) profile and `expansion-identifier` equal to `eCQM%20Update%202020-05-07`
 
 ```
-[base]/Library?_profile=http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/quality-program-cqfm&expansion-name=eCQM%20Update%202020-05-07
+[base]/Library?_profile=http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/quality-program-cqfm&expansion-identifier=eCQM%20Update%202020-05-07
 ```
 
-The Library resource(s) that match have the canonical for the value sets listed in Library.relatedArtifact.resource with relatedArtifact.type equal to "depends-on".
+The Library resource(s) that match will have the canonical for the value sets listed in Library.relatedArtifact.resource with relatedArtifact.type equal to "depends-on".
 
-Another way is to use the expansion identifier (`eCQM%20Update%202020-05-07` in this example) in a ValueSet search
+Another way to discover value sets associated with a given expansion identifier is to use the expansion identifier (`eCQM%20Update%202020-05-07` in this example) in a ValueSet search
 
 ```
 [base]/ValueSet?expansion=eCQM%20Update%202020-05-07

--- a/input/pages/measure-terminology-service.md
+++ b/input/pages/measure-terminology-service.md
@@ -38,6 +38,28 @@ Because this capability results in the potential for parameter values to be supp
 4. Version information specified in the expansion parameters takes precedence over version information specified as part of the version manifest (i.e. as a relatedArtifact dependency in the artifact collection library)
 5. When processing an expand (or any artifact operation that will encounter canonical references), when an un-versioned canonical reference is encountered, the manifest is consulted to determine a version of the artifact to be used for that reference.
 
+For example, the following snippet is from a value set that includes two other value sets without specifying a version for them (an un-versioned canonical), but the manifest SHOULD contain the canonical with version for those included value sets.
+
+```
+ "compose": {
+    "include": [ {
+      "valueSet": [ "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1078" ]
+    }, {
+      "valueSet": [ "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1079" ]
+    } ]
+  }
+```
+To continue with this example, the manifest `relatedArtifact.resource` would contain the version, as shown below:
+
+```
+  "relatedArtifact": [ {
+    "type": "depends-on",
+    "display": "Cancer",
+    "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1078|20220218"
+  }, ...
+  ```
+
+
 #### Quality Programs
 To support organization of releases, the Quality Program profile can also be used to define quality programs that contain multiple releases over multiple years. This usage is represented by an overall Quality Program that is then referenced by each release using the [partOf](StructureDefinition-cqfm-partOf.html) extension.
 
@@ -567,6 +589,8 @@ The full example is available here:
 
 To discover what values of the $expand `expansion` parameter are supported by the Measure Terminology Service, start with a Library search using the `_profile` parameter to limit the search to [CQFMQualityProgram](StructureDefinition-quality-program-cqfm.html), and the `contained-parameter-name` search parameter with the value `expansion`.
 
+Note that some terminology servers support the use of persisted expansions to ensure stable expansion of value sets included as part of a release. This approach provides an alternative to explicitly stating binding versions for all the unreferenced canonical references used in the artifacts included in a release. Because expansion identifiers are server-specific, the preferred approach is to make use of the version manifest to state binding versions. However, the use of expansion identifiers MAY be used as an alternative.
+
 If Library.contained.parameter.name matches the contained-parameter-name search parameter, then return this Library in the searchset.
 
 For example, 
@@ -574,7 +598,7 @@ For example,
 [base]/Library?_profile=http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/quality-program-cqfm&contained-parameter-name=expansion
 ```
 
-That example searches for CQFM Quality Program Library resources that have Library.contained.parameter.name equal to the string `expansion`. The corresponding Library.contained.parameter.valueUri is the expansion identifier, which can be used in a ValueSet $expand. If the previous Library search found a ValurUri with "eCQM%20Update%202020-05-07", then use it in the `expansion` parameter:  
+That example searches for CQFM Quality Program Library resources that have Library.contained.parameter.name equal to the string `expansion`. The corresponding Library.contained.parameter.valueUri is the expansion identifier, which can be used in a ValueSet $expand. If the previous Library search found a ValurUri with "eCQM%20Update%202020-05-07", then use it in a ValueSet search with the `expansion` parameter:  
 ```
 [base]/Valueset/[id]/$expand?expansion=eCQM%20Update%202020-05-07
 ```

--- a/input/pages/measure-terminology-service.md
+++ b/input/pages/measure-terminology-service.md
@@ -183,7 +183,7 @@ Note that when a code system authority has not established a versioning system, 
     2. version: Returning the quality program matching that version (can appear only in combination with a url search)
     3. identifier: Returning any quality program matching the identifier
     4. name: Returning any quality program matching the name, according to the string-matching semantics in FHIR
-    5. title: Returning any quality program matching the title, according to the string-matching semantics in FHIReCQM%20Update%202020-05-07
+    5. title: Returning any quality program matching the title, according to the string-matching semantics in FHIR
     6. status: Returning quality programs that match the given status
     7. description: Returning any quality programs matching the search description, according to string-matching semantics in FHIR
     8. composed-of: Returning any quality program that includes the given measure canonical or quality program version manifest or release

--- a/input/pages/measure-terminology-service.md
+++ b/input/pages/measure-terminology-service.md
@@ -183,7 +183,7 @@ Note that when a code system authority has not established a versioning system, 
     2. version: Returning the quality program matching that version (can appear only in combination with a url search)
     3. identifier: Returning any quality program matching the identifier
     4. name: Returning any quality program matching the name, according to the string-matching semantics in FHIR
-    5. title: Returning any quality program matching the title, according to the string-matching semantics in FHIR
+    5. title: Returning any quality program matching the title, according to the string-matching semantics in FHIReCQM%20Update%202020-05-07
     6. status: Returning quality programs that match the given status
     7. description: Returning any quality programs matching the search description, according to string-matching semantics in FHIR
     8. composed-of: Returning any quality program that includes the given measure canonical or quality program version manifest or release
@@ -562,19 +562,29 @@ To discover what values of the $expand `expansion` parameter are supported by th
 
 If Library.contained.parameter.name matches the contained-parameter-name search parameter, then return this Library in the searchset.
 
-For example, [base]/Library?_profile=http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/quality-program-cqfm&contained-parameter-name=expansion
+For example, 
+```
+[base]/Library?_profile=http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/quality-program-cqfm&contained-parameter-name=expansion
+```
 
-That example searches for CQFM Quality Program Library resources that have Library.contained.parameter.name equal to the string `expansion`. The corresponding Library.contained.parameter.valueUri is the expansion identifier, which can be used in a ValueSet $expand. If the previous Library search found a ValurUri with "eCQM%20Update%202020-05-07", then use it in the `expansion` parameter:  [base]/Valueset/[id]/$expand?expansion=eCQM%20Update%202020-05-07 
+That example searches for CQFM Quality Program Library resources that have Library.contained.parameter.name equal to the string `expansion`. The corresponding Library.contained.parameter.valueUri is the expansion identifier, which can be used in a ValueSet $expand. If the previous Library search found a ValurUri with "eCQM%20Update%202020-05-07", then use it in the `expansion` parameter:  
+```
+[base]/Valueset/[id]/$expand?expansion=eCQM%20Update%202020-05-07
+```
 
-To discover what value sets are associated with an expansion named "xxx", you can search for a Library with the [CQFMQualityProgram](StructureDefinition-quality-program-cqfm.html) profile and `expansion-identifier` equal to "eCQM%20Update%202020-05-07"
+To discover what value sets are associated with an expansion named `eCQM%20Update%202020-05-07`, you can search for a Library with the [CQFMQualityProgram](StructureDefinition-quality-program-cqfm.html) profile and `expansion-identifier` equal to `eCQM%20Update%202020-05-07`
 
+```
 [base]/Library?_profile=http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/quality-program-cqfm&expansion-name=eCQM%20Update%202020-05-07
+```
 
 The Library resource(s) that match have the canonical for the value sets listed in Library.relatedArtifact.resource with relatedArtifact.type equal to "depends-on".
 
 Another way is to use the expansion identifier (`eCQM%20Update%202020-05-07` in this example) in a ValueSet search
 
+```
 [base]/ValueSet?expansion=eCQM%20Update%202020-05-07
+```
 
 ##### Expansion with manifests and releases:
 

--- a/input/resources/SearchParameter-Library-contained-parameter-name.json
+++ b/input/resources/SearchParameter-Library-contained-parameter-name.json
@@ -1,0 +1,37 @@
+{
+  "base": [
+     "Library"
+  ],
+  "code": "name",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://hl7.org/fhir"
+        }
+      ]
+    },
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://www.hl7.org/Special/committees/cqi/index.cfm"
+        }
+      ]
+    }
+  ],
+  "date": "2023-05-25T13:00:00-05:00",
+  "description": "Parameters.parameter.name within Library.contained",
+  "experimental": false,
+  "expression": "Library.contained.parameter.name",
+  "id": "Library-contained-parameter-name",
+  "name": "contained-parameter-name",
+  "publisher": "Health Level Seven International (Clinical Quality Information)",
+  "resourceType": "SearchParameter",
+  "status": "draft",
+  "type": "string",
+  "url": "http://hl7.org/fhir/us/cqfmeasures/SearchParameter/Library-contained-parameter-name",
+  "xpath": "f:Library/f:contained/f:parameter/f:name",
+  "xpathUsage": "normal"
+}

--- a/input/resources/SearchParameter-Library-contained-parameter-name.json
+++ b/input/resources/SearchParameter-Library-contained-parameter-name.json
@@ -2,7 +2,7 @@
   "base": [
      "Library"
   ],
-  "code": "name",
+  "code": "contained-parameter-name",
   "contact": [
     {
       "telecom": [

--- a/input/resources/SearchParameter-Library-expansion-identifier.json
+++ b/input/resources/SearchParameter-Library-expansion-identifier.json
@@ -1,0 +1,37 @@
+{
+  "base": [
+     "Library"
+  ],
+  "code": "name",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://hl7.org/fhir"
+        }
+      ]
+    },
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://www.hl7.org/Special/committees/cqi/index.cfm"
+        }
+      ]
+    }
+  ],
+  "date": "2023-05-25T13:00:00-05:00",
+  "description": "Parameters.parameter.valueUri within Library.contained",
+  "experimental": false,
+  "expression": "Library.contained.parameter.valueUri",
+  "id": "Library-expansion-identifier",
+  "name": "expansion-identifier",
+  "publisher": "Health Level Seven International (Clinical Quality Information)",
+  "resourceType": "SearchParameter",
+  "status": "draft",
+  "type": "string",
+  "url": "http://hl7.org/fhir/us/cqfmeasures/SearchParameter/Library-expansion-identifier",
+  "xpath": "f:Library/f:contained/f:parameter/f:valueUri",
+  "xpathUsage": "normal"
+}

--- a/input/resources/SearchParameter-Library-expansion-identifier.json
+++ b/input/resources/SearchParameter-Library-expansion-identifier.json
@@ -24,7 +24,7 @@
   "date": "2023-05-25T13:00:00-05:00",
   "description": "Parameters.parameter.valueUri within Library.contained",
   "experimental": false,
-  "expression": "Library.contained.parameter.valueUri",
+  "expression": "Library.contained.where(resourceType='Parameters').parameter.where(name='expansion').valueUri",
   "id": "Library-expansion-identifier",
   "name": "expansion-identifier",
   "publisher": "Health Level Seven International (Clinical Quality Information)",
@@ -32,6 +32,6 @@
   "status": "draft",
   "type": "string",
   "url": "http://hl7.org/fhir/us/cqfmeasures/SearchParameter/Library-expansion-identifier",
-  "xpath": "f:Library/f:contained/f:parameter/f:valueUri",
+  "xpath": "f:Library/f:contained[f:resourceType='Parameters']/f:parameter[f:name='expansion']/f:valueUri",
   "xpathUsage": "normal"
 }

--- a/input/resources/SearchParameter-Library-expansion-identifier.json
+++ b/input/resources/SearchParameter-Library-expansion-identifier.json
@@ -2,7 +2,7 @@
   "base": [
      "Library"
   ],
-  "code": "name",
+  "code": "expansion-identifier",
   "contact": [
     {
       "telecom": [

--- a/input/resources/SearchParameter-ValueSet-keyword.json
+++ b/input/resources/SearchParameter-ValueSet-keyword.json
@@ -1,0 +1,37 @@
+{
+  "base": [
+     "ValueSet"
+  ],
+  "code": "keyword",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://hl7.org/fhir"
+        }
+      ]
+    },
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://www.hl7.org/Special/committees/cqi/index.cfm"
+        }
+      ]
+    }
+  ],
+  "date": "2023-06-12T13:00:00-05:00",
+  "description": "Search within the keyword extension",
+  "experimental": false,
+  "expression": "ValueSet.extension.where(url='http://hl7.org/fhir/StructureDefinition/valueset-keyWord').valueString",
+  "id": "ValueSet-keyword",
+  "name": "keyword",
+  "publisher": "Health Level Seven International (Clinical Quality Information)",
+  "resourceType": "SearchParameter",
+  "status": "draft",
+  "type": "string",
+  "url": "http://hl7.org/fhir/us/cqfmeasures/SearchParameter/ValueSet-keyword",
+  "xpath": "f:ValueSet/f:extension[f:url='http://hl7.org/fhir/StructureDefinition/valueset-keyWord']/f:valueString",
+  "xpathUsage": "normal"
+}

--- a/input/resources/capabilitystatement-measure-terminology-service.xml
+++ b/input/resources/capabilitystatement-measure-terminology-service.xml
@@ -247,11 +247,19 @@
       </searchParam>
       <searchParam>
 				<extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-					<valueCode value="SHALL" />
+					<valueCode value="MAY" />
 				</extension>
 				<name value="expansion" />
 				<definition value="http://hl7.org/fhir/SearchParameter/ValueSet-expansion" />
 				<type value="uri" />
+			</searchParam>
+      <searchParam>
+				<extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+					<valueCode value="SHALL" />
+				</extension>
+				<name value="keyword" />
+				<definition value="http://hl7.org/fhir/us/cqfmeasures/SearchParameter/ValueSet-keyword" />
+				<type value="string" />
 			</searchParam>
     </resource>
     <resource>
@@ -365,7 +373,7 @@
         </extension>
         <name value="expansion-identifier"/>
         <definition value="http://hl7.org/fhir/us/cqfmeasures/SearchParameter/Library-expansion-identifier"/>
-        <type value="string"/>
+        <type value="uri"/>
       </searchParam>
     </resource>
     <operation>
@@ -377,7 +385,7 @@
     </operation>
     <operation>
       <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-        <valueCode value="SHOULD"/>
+        <valueCode value="SHALL"/>
       </extension>
       <name value="expand"/>
       <definition value="http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/ValueSet-expand"/>

--- a/input/resources/capabilitystatement-measure-terminology-service.xml
+++ b/input/resources/capabilitystatement-measure-terminology-service.xml
@@ -363,8 +363,8 @@
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
           <valueCode value="SHALL"/>
         </extension>
-        <name value="expansion-name"/>
-        <definition value="http://hl7.org/fhir/us/cqfmeasures/SearchParameter/Library-expansion-name"/>
+        <name value="expansion-identifier"/>
+        <definition value="http://hl7.org/fhir/us/cqfmeasures/SearchParameter/Library-expansion-identifier"/>
         <type value="string"/>
       </searchParam>
     </resource>

--- a/input/resources/capabilitystatement-measure-terminology-service.xml
+++ b/input/resources/capabilitystatement-measure-terminology-service.xml
@@ -245,6 +245,14 @@
         <definition value="http://hl7.org/fhir/SearchParameter/conformance-context-type-value"/>
         <type value="composite"/>
       </searchParam>
+      <searchParam>
+				<extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+					<valueCode value="SHALL" />
+				</extension>
+				<name value="expansion" />
+				<definition value="http://hl7.org/fhir/SearchParameter/ValueSet-expansion" />
+				<type value="uri" />
+			</searchParam>
     </resource>
     <resource>
       <type value="Library"/>
@@ -342,6 +350,22 @@
         <name value="depends-on"/>
         <definition value="http://hl7.org/fhir/SearchParameter/Library-composed-of"/>
         <type value="reference"/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <name value="contained-parameter-name"/>
+        <definition value="http://hl7.org/fhir/us/cqfmeasures/SearchParameter/Library-contained-parameter-name"/>
+        <type value="string"/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <name value="expansion-name"/>
+        <definition value="http://hl7.org/fhir/us/cqfmeasures/SearchParameter/Library-expansion-name"/>
+        <type value="string"/>
       </searchParam>
     </resource>
     <operation>

--- a/input/resources/operationdefinition-cqfm-valueset-expand.json
+++ b/input/resources/operationdefinition-cqfm-valueset-expand.json
@@ -208,7 +208,7 @@
     "use" : "in",
     "min" : 0,
     "max" : "1",
-    "documentation" : "Specifies an expansion identifier to be used. If the value set has an expansion with that identifier, that expansion is used. This parameter has the same behavior as using the `expansion` search parameter with the canonical url for the value set.  If the server performing the expand does not know the expansion identifier, it SHALL return an error. An expansion parameter takes precedence over other parameters that control expansion, since the expansion identifier establishes the expansion to be returned.",
+    "documentation" : "Specifies an expansion identifier to be used. If the value set has an expansion with that identifier, that expansion is used. This parameter has the same behavior as using the `expansion` search parameter with the canonical url for the value set. If the server performing the expand does not know the expansion identifier, it SHALL return an error. An expansion parameter takes precedence over other parameters that control expansion, since the expansion identifier establishes the expansion to be returned.",
     "type" : "uri"
   },
   {

--- a/input/resources/operationdefinition-cqfm-valueset-expand.json
+++ b/input/resources/operationdefinition-cqfm-valueset-expand.json
@@ -208,8 +208,8 @@
     "use" : "in",
     "min" : 0,
     "max" : "1",
-    "documentation" : "Specifies an expansion identifier to be used. If the value set has an expansion with that identifier, that expansion is used. This parameter has the same behavior as using the `expansion` search parameter with the canonical url for the value set. If the server performing the expand does not know the expansion identifier, it SHALL return an error. An expansion parameter takes precedence over other parameters that control expansion, since the expansion identifier establishes the expansion to be returned.",
-    "type" : "uri"
+    "documentation" : "Specifies an expansion identifier to be used. If the value set has an expansion with that name, that expansion is used. If the server performing the expand does not know the expansion identifier, it SHALL return an error. An expansion parameter takes precedence over other parameters that control expansion, since the expansion identifier establishes the expansion to be returned.",
+    "type" : "string"
   },
   {
     "name" : "includeDraft",

--- a/input/resources/operationdefinition-cqfm-valueset-expand.json
+++ b/input/resources/operationdefinition-cqfm-valueset-expand.json
@@ -208,8 +208,8 @@
     "use" : "in",
     "min" : 0,
     "max" : "1",
-    "documentation" : "Specifies an expansion identifier to be used. If the value set has an expansion with that name, that expansion is used. If the server performing the expand does not know the expansion identifier, it SHALL return an error. An expansion parameter takes precedence over other parameters that control expansion, since the expansion identifier establishes the expansion to be returned.",
-    "type" : "string"
+    "documentation" : "Specifies an expansion identifier to be used. If the value set has an expansion with that identifier, that expansion is used. This parameter has the same behavior as using the `expansion` search parameter with the canonical url for the value set.  If the server performing the expand does not know the expansion identifier, it SHALL return an error. An expansion parameter takes precedence over other parameters that control expansion, since the expansion identifier establishes the expansion to be returned.",
+    "type" : "uri"
   },
   {
     "name" : "includeDraft",

--- a/input/resources/operationdefinition-cqfm-valueset-expand.json
+++ b/input/resources/operationdefinition-cqfm-valueset-expand.json
@@ -220,6 +220,30 @@
     "type" : "boolean"
   },
   {
+    "name": "canonicalVersion",
+    "min": 0,
+    "max": "*",
+    "use": "in",
+    "type": "canonical",
+    "documentation": "Specifies a version to use for a canonical resource if the artifact referencing \nthe resource does not already specify a version. The format is the same as a canonical URL:\n[url]|[version] - e.g. http://loinc.org|2.56 Note that this is a generalization of the `system-version`\nparameter to the $expand operation to apply to any canonical resource, including code systems."
+  },
+  {
+    "name": "checkCanonicalVersion",
+    "min": 0,
+    "max": "*",
+    "use": "in",
+    "type": "canonical",
+    "documentation": "Edge Case: Specifies a version to use for a canonical resource. If the artifact referencing \nthe resource specifies a different version, an error is returned instead of the package. The\nformat is the same as a canonical URL: [url]|[version] - e.g. http://loinc.org|2.56 Note that\nthis is a generalization of the `check-system-version` parameter to the $expand operation to \napply to any canonical resource, including code systems."
+  },
+  {
+    "name": "forceCanonicalVersion",
+    "min": 0,
+    "max": "*",
+    "use": "in",
+    "type": "canonical",
+    "documentation": "Edge Case: Specifies a version to use for a canonical resource. This parameter overrides any\nspecified version in the artifact (and any artifacts it depends on). The\nformat is the same as a canonical URL: [system]|[version] - e.g.\nhttp://loinc.org|2.56. Note that this has obvious safety issues, in that it may\nresult in a value set expansion giving a different list of codes that is both\nwrong and unsafe, and implementers should only use this capability reluctantly.\nIt primarily exists to deal with situations where specifications have fallen\ninto decay as time passes. If the version of a canonical is overriden, the version used SHALL\nexplicitly be represented in the expansion parameters. Note that this is a generalization of the\n`force-system-version` parameter to the $expand operation to apply to any canonical resource,\nincluding code systems."
+  },
+  {
     "name" : "return",
     "use" : "out",
     "min" : 1,


### PR DESCRIPTION
adds 2 search params for Library, and adds them to capability statement for measure terminology service.  Also updates capability statement to make ValueSet $expand `expansion `parameter mandatory.
(adds download link for package.tgz, not part of FHIR-40210, just nice to have)

added text to measure-terminology-service.md to explain how to use the 2 new search parameters: search for expansion identifiers and search for CQFM quality program library resources with a particular expansion identifier to find which value sets are part of the program release.

https://jira.hl7.org/browse/FHIR-40210 