### PR TITLE
Removing .escape('html') as it appears to be rendering the escaped characters twice.

### DIFF
--- a/templates/liquid/Library.liquid
+++ b/templates/liquid/Library.liquid
@@ -374,18 +374,7 @@
           <td colspan="2">
             <table>
               <tr><th><a id="cql-content"><b>Content: </b></a> {{c.contentType}}</th></tr>
-              <tr><td><pre><code class="language-cql" id="code-block">
-              
-              <script>  
-                document.addEventListener('DOMContentLoaded', function() {
-                var element = document.getElementById('code-block');
-                  var decodedString = atob('{{c.data}}');
-                  element.innerHTML = decodedString;
-                });
-
-              </script>
-
-              </code></pre></td></tr>
+              <tr><td><pre><code class="language-cql">{{c.data.decode('base64')}}</code></pre></td></tr>
             </table>
           </td>
         </tr>


### PR DESCRIPTION
This is a correction of an earlier addressed bug in which javascript was incorporated into the liquid template. 