### PR TITLE
FHIR-27930 Add PI measure example (no library)

### DIFF
--- a/FHIR-us-qm.xml
+++ b/FHIR-us-qm.xml
@@ -19,7 +19,7 @@
 <artifact id="CodeSystem/artifact-comment-type" key="CodeSystem-artifact-comment-type" name="Artifact Comment Type Codes"/>
 <artifact id="Library/BCSComponent" key="Library-BCSComponent" name="BCS Component Library"/>
 <artifact id="Measure/BCSComponent" key="Measure-BCSComponent" name="Breast Cancer Screening"/>
-<artifact id="Measure/BreastCancerScreeningFHIR" key="Measure-BreastCancerScreeningFHIR" name="Breast Cancer Screening FHIR Measure"/>
+<artifact deprecated="true" id="Measure/BreastCancerScreeningFHIR" key="Measure-BreastCancerScreeningFHIR" name="Breast Cancer Screening FHIR Measure"/>
 <artifact id="Library/CCSComponent" key="Library-CCSComponent" name="CCS Component Library"/>
 <artifact id="Library/ecqm-quality-program" key="Library-ecqm-quality-program" name="CMS eCQM and Hybrid Measures"/>
 <artifact id="CapabilityStatement/authoring-measure-repository" key="CapabilityStatement-authoring-measure-repository" name="CQF Measures Authoring Measure Repository Capability Statement"/>
@@ -27,7 +27,7 @@
 <artifact id="CapabilityStatement/publishable-measure-repository" key="CapabilityStatement-publishable-measure-repository" name="CQF Measures Publishable Measure Repository Capability Statement"/>
 <artifact id="CapabilityStatement/shareable-measure-repository" key="CapabilityStatement-shareable-measure-repository" name="CQF Measures Shareable Measure Repository Capability Statement"/>
 <artifact id="StructureDefinition/cqfm-aggregateMethod" key="StructureDefinition-cqfm-aggregateMethod" name="CQFM Aggregate Method"/>
-<artifact id="StructureDefinition/cqfm-allocation" key="StructureDefinition-cqfm-allocation" name="CQFM Allocation"/>
+<artifact deprecated="true" id="StructureDefinition/cqfm-allocation" key="StructureDefinition-cqfm-allocation" name="CQFM Allocation"/>
 <artifact id="StructureDefinition/cqfm-appliesTo" key="StructureDefinition-cqfm-appliesTo" name="CQFM Applies To"/>
 <artifact id="StructureDefinition/cqfm-artifactComment" key="StructureDefinition-cqfm-artifactComment" name="CQFM Artifact Comment"/>
 <artifact id="StructureDefinition/cqfm-cqlOptions" key="StructureDefinition-cqfm-cqlOptions" name="CQFM CQL Options"/>
@@ -55,6 +55,7 @@
 <artifact id="StructureDefinition/cqfm-fhirQueryPattern" key="StructureDefinition-cqfm-fhirQueryPattern" name="CQFM FHIR Query Pattern"/>
 <artifact id="StructureDefinition/cqfm-groupId" key="StructureDefinition-cqfm-groupId" name="CQFM Group Id"/>
 <artifact id="StructureDefinition/cqfm-improvementNotation" key="StructureDefinition-cqfm-improvementNotation" name="CQFM Improvement Notation"/>
+<artifact id="StructureDefinition/cqfm-includeInReportType" key="StructureDefinition-cqfm-includeInReportType" name="CQFM Include In Report Type"/>
 <artifact id="StructureDefinition/cqfm-inputParameters" key="StructureDefinition-cqfm-inputParameters" name="CQFM Input Parameters"/>
 <artifact id="StructureDefinition/cqfm-isPrimaryCitation" key="StructureDefinition-cqfm-isPrimaryCitation" name="CQFM Is Primary Citation"/>
 <artifact id="StructureDefinition/cqfm-isSelective" key="StructureDefinition-cqfm-isSelective" name="CQFM Is Selective"/>
@@ -83,6 +84,7 @@
 <artifact id="StructureDefinition/cqfm-scoring" key="StructureDefinition-cqfm-scoring" name="CQFM Scoring"/>
 <artifact id="StructureDefinition/cqfm-scoringUnit" key="StructureDefinition-cqfm-scoringUnit" name="CQFM Scoring Unit"/>
 <artifact id="StructureDefinition/cqfm-softwaresystem" key="StructureDefinition-cqfm-softwaresystem" name="CQFM Software System"/>
+<artifact id="StructureDefinition/cqfm-supplementalDataGuidance" key="StructureDefinition-cqfm-supplementalDataGuidance" name="CQFM Supplemental Data Guidance"/>
 <artifact id="StructureDefinition/cqfm-supportedCqlVersion" key="StructureDefinition-cqfm-supportedCqlVersion" name="CQFM Supported CQL Version"/>
 <artifact id="StructureDefinition/test-case-cqfm" key="StructureDefinition-test-case-cqfm" name="CQFM Test Case"/>
 <artifact id="StructureDefinition/cqfm-testCaseDescription" key="StructureDefinition-cqfm-testCaseDescription" name="CQFM Test Case Description"/>
@@ -106,24 +108,29 @@
 <artifact id="ConceptMap/data-usages" key="ConceptMap-data-usages" name="Data Usage Mapping"/>
 <artifact id="Device/software-system-example" key="Device-software-system-example" name="Device - Software System Example"/>
 <artifact id="Library/ep-ec-quality-program" key="Library-ep-ec-quality-program" name="EP/EC Quality Program"/>
-<artifact id="Measure/measure-exm" key="Measure-measure-exm" name="EXM Measure"/>
+<artifact id="Measure/EXMLogic-FHIR" key="Measure-measure-exm" name="EXM Measure"/>
+<artifact id="Measure/measure-pi-exm" key="Measure-measure-pi-exm" name="EXM Promoting Interoperability Measure"/>
 <artifact id="Measure/measure-publishable-exm" key="Measure-measure-publishable-exm" name="EXM Publishable Measure"/>
-<artifact id="Measure/measure-ratio-exm" key="Measure-measure-ratio-exm" name="EXM Ratio Measure"/>
-<artifact id="Library/EXM108" key="Library-EXM108" name="EXM108 - Venous Thromboembolism Prophylaxis Library"/>
-<artifact id="Measure/measure-exm124-FHIR" key="Measure-measure-exm124-FHIR" name="EXM124 - Cervical Cancer Screening"/>
-<artifact id="Library/EXM124" key="Library-EXM124" name="EXM124 - Cervical Cancer Screening Library"/>
-<artifact id="Library/EXM125" key="Library-EXM125" name="EXM125 - Breast Cancer Screening Library"/>
-<artifact id="Measure/measure-exm125-FHIR" key="Measure-measure-exm125-FHIR" name="EXM125 - Breast Cancer Screening Measure"/>
-<artifact id="Library/EXM130" key="Library-EXM130" name="EXM130 - Colorectal Cancer Screening Library"/>
-<artifact id="Measure/measure-exm130-FHIR" key="Measure-measure-exm130-FHIR" name="EXM130 - Colorectal Cancer Screening Measure"/>
-<artifact id="Measure/measure-exm146-FHIR" key="Measure-measure-exm146-FHIR" name="EXM146 - Appropriate Testing for Children with Pharyngitis"/>
-<artifact id="Library/EXM146" key="Library-EXM146" name="EXM146 - Example Proportion Measure Library"/>
-<artifact id="Library/EXM55" key="Library-EXM55" name="EXM55 - Example Continuous Variable Measure Library"/>
-<artifact id="Measure/measure-exm55-FHIR" key="Measure-measure-exm55-FHIR" name="EXM55 - Median ED Visit Duration"/>
-<artifact id="Library/EXMRatio" key="Library-EXMRatio" name="EXMRatio - Example Ratio Measure Library"/>
+<artifact id="Measure/EXMRatio-FHIR" key="Measure-measure-ratio-exm" name="EXM Ratio Measure"/>
+<artifact id="Measure/EXM108-FHIR" key="Measure-EXM108-FHIR" name="EXM108 - Venous Thromboembolism Prophylaxis"/>
+<artifact id="Library/EXM108-FHIR" key="Library-EXM108" name="EXM108 - Venous Thromboembolism Prophylaxis Library"/>
+<artifact id="Measure/EXM124-FHIR" key="Measure-measure-exm124-FHIR" name="EXM124 - Cervical Cancer Screening"/>
+<artifact id="Library/EXM124-FHIR" key="Library-EXM124" name="EXM124 - Cervical Cancer Screening Library"/>
+<artifact id="Measure/EXM125-FHIR" key="Measure-EXM125-FHIR" name="EXM125 - Breast Cancer Screening"/>
+<artifact id="Library/EXM125-FHIR" key="Library-EXM125" name="EXM125 - Breast Cancer Screening Library"/>
+<artifact deprecated="true" id="Measure/measure-exm125-FHIR" key="Measure-measure-exm125-FHIR" name="EXM125 - Breast Cancer Screening Measure"/>
+<artifact id="Library/EXM130-FHIR" key="Library-EXM130" name="EXM130 - Colorectal Cancer Screening Library"/>
+<artifact id="Measure/EXM130-FHIR" key="Measure-measure-exm130-FHIR" name="EXM130 - Colorectal Cancer Screening Measure"/>
+<artifact id="Measure/EXM146-FHIR" key="Measure-measure-exm146-FHIR" name="EXM146 - Appropriate Testing for Children with Pharyngitis"/>
+<artifact id="Library/EXM146-FHIR" key="Library-EXM146" name="EXM146 - Example Proportion Measure Library"/>
+<artifact deprecated="true" id="Library/EXM55" key="Library-EXM55" name="EXM55 - Example Continuous Variable Measure Library"/>
+<artifact deprecated="true" id="Measure/measure-exm55-FHIR" key="Measure-measure-exm55-FHIR" name="EXM55 - Median ED Visit Duration"/>
+<artifact id="Measure/EXM55-FHIR" key="Measure-EXM55-FHIR" name="EXM55 - Median Emergency Department Visit Duration"/>
+<artifact id="Library/EXM55-FHIR" key="Library-EXM55-FHIR" name="EXM55 - Median Emergency Department Visit Duration (Example Continuous Variable Measure Library)"/>
+<artifact id="Library/EXMRatio-FHIR" key="Library-EXMRatio" name="EXMRatio - Example Ratio Measure Library"/>
 <artifact id="Library/EXMComputableLibrary" key="Library-EXMComputableLibrary" name="Example Computable Library"/>
 <artifact id="Library/EXMExecutableLibrary" key="Library-EXMExecutableLibrary" name="Example Executable Library"/>
-<artifact id="Library/EXMLogic" key="Library-EXMLogic" name="Example Logic Library"/>
+<artifact id="Library/EXMLogic-FHIR" key="Library-EXMLogic" name="Example Logic Library"/>
 <artifact id="Library/EXMLogic-ModuleDefinition" key="Library-EXMLogic-ModuleDefinition" name="Example Logic Library - Module Definition"/>
 <artifact id="Library/EXMPublishableLibrary" key="Library-EXMPublishableLibrary" name="Example Publishable Library"/>
 <artifact id="ValueSet/executable-example" key="ValueSet-executable-example" name="Executable Example"/>
@@ -152,11 +159,11 @@
 <artifact id="ConceptMap/measure-scoring" key="ConceptMap-measure-scoring" name="Measure Scoring mapping"/>
 <artifact id="CapabilityStatement/measure-terminology-service" key="CapabilityStatement-measure-terminology-service" name="Measure Terminology Service Capability Statement"/>
 <artifact id="ConceptMap/measure-types" key="ConceptMap-measure-types" name="Measure Type mapping"/>
-<artifact id="Measure/measure-exm-default" key="Measure-measure-exm-default" name="Measure with default value measurement period"/>
+<artifact deprecated="true" id="Measure/measure-exm-default" key="Measure-measure-exm-default" name="Measure with default value measurement period"/>
 <artifact id="MeasureReport/testcase-example" key="MeasureReport-testcase-example" name="MeasureReport - Test Case Example"/>
 <artifact id="OperationDefinition/MeasureReport-package" key="OperationDefinition-MeasureReport-package" name="MeasureReport Packaging"/>
-<artifact id="Library/MultiRateExample" key="Library-MultiRateExample" name="Multi Rate Example Logic Library"/>
-<artifact id="Measure/multi-rate-example" key="Measure-multi-rate-example" name="Multi-Rate Example Measure"/>
+<artifact id="Library/MultiRateExample-FHIR" key="Library-MultiRateExample" name="Multi Rate Example Logic Library"/>
+<artifact id="Measure/MultiRateExample-FHIR" key="Measure-multi-rate-example" name="Multi-Rate Example Measure"/>
 <artifact id="Library/PVSComponent" key="Library-PVSComponent" name="PVS Component Library"/>
 <artifact id="Measure/PVSComponent" key="Measure-PVSComponent" name="Pneumococcal Vaccination Status for Older Adults"/>
 <artifact id="Measure/HBPComponent" key="Measure-HBPComponent" name="Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented"/>
@@ -182,12 +189,12 @@
 <artifact id="Library/SupplementalDataElements" key="Library-SupplementalDataElements" name="Supplemental Data Elements Library"/>
 <artifact id="Library/TJCOverall" key="Library-TJCOverall" name="TJC Overall Library"/>
 <artifact id="Library/TSCComponent" key="Library-TSCComponent" name="TSC Component Library"/>
-<artifact id="Measure/measure-terminology-FHIR" key="Measure-measure-terminology-FHIR" name="Terminology FHIR"/>
-<artifact id="Library/Terminology" key="Library-Terminology" name="Terminology Library"/>
+<artifact id="Measure/Terminology-FHIR" key="Measure-measure-terminology-FHIR" name="Terminology FHIR"/>
+<artifact id="Library/Terminology-FHIR" key="Library-Terminology" name="Terminology Library"/>
 <artifact id="Library/USCore-ModelInfo" key="Library-USCore-ModelInfo" name="USCore Model Definition"/>
 <artifact id="Library/VTEICU" key="Library-VTEICU" name="VTE ICU Library"/>
 <artifact id="ValueSet/value-filter-comparator" key="ValueSet-value-filter-comparator" name="Value Filter Comparator"/>
-<artifact id="Measure/measure-vte-1-FHIR" key="Measure-measure-vte-1-FHIR" name="Venous Thromboembolism Prophylaxis"/>
+<artifact deprecated="true" id="Measure/measure-vte-1-FHIR" key="Measure-measure-vte-1-FHIR" name="Venous Thromboembolism Prophylaxis"/>
 <artifact id="Library/ecqm-update-2020" key="Library-ecqm-update-2020" name="eCQM Annual Update 2020"/>
 <artifact id="Library/ecqm-update-2020-05-07" key="Library-ecqm-update-2020-05-07" name="eCQM Update 2020-05-07"/>
 <page key="NA" name="(NA)"/>
@@ -208,11 +215,11 @@
 <page key="measure-terminology-service" name="Measure Terminology Service"/>
 <page key="packaging" name="Packaging"/>
 <page key="profiles" name="Profiles"/>
+<page key="measure-conformance" name="QMs"/>
 <page key="index" name="Quality Measure Implementation Guide Homepage"/>
 <page key="toc" name="Table of Contents"/>
 <page key="terminology" name="Terminology"/>
 <page key="using-cql" name="Using CQL"/>
 <page deprecated="true" key="ecqm-basics" name="eCQM Basics"/>
-<page key="measure-conformance" name="eCQMs"/>
 <page deprecated="true" key="history" name="history"/>
 </specification>

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -185,3 +185,4 @@ These changes will be published as part of the STU3 release (v3.0.0)
 * [**FHIR-28206**](https://jira.hl7.org/browse/FHIR-28206): Updated glossary terms
 * [**FHIR-26331**](https://jira.hl7.org/browse/FHIR-26331): Corrected breadcrumbs display throughout the IG
 * [**FHIR-26329**](https://jira.hl7.org/browse/FHIR-26329): Updated the IG to use the standard HL7 FHIR IG template
+* [**FHIR-27930**](https://jira.hl7.org/browse/FHIR-27930): Added PI Measure example (no library)

--- a/input/data/package-list.yml
+++ b/input/data/package-list.yml
@@ -45,3 +45,4 @@ list:
       1. **Applied**: Clarified definition wording for usage element of Publishable Measure CQFM  ([FHIR-40241](https://jira.hl7.org/browse/FHIR-40241))
       1. **Applied**: Updated Quality Programs code system, value set and Structured Definition, cardinality of program slice to 0..1, binding to 'example', updated guidance.  ([FHIR-40562](https://jira.hl7.org/browse/FHIR-40562))
       1. **Applied**: Removed measure allocation extension and all references to it throughout  ([FHIR-40590](https://jira.hl7.org/browse/FHIR-40590))
+      1. **Applied**: Added PI Measure example (no library) [FHIR-27930](https://jira.hl7.org/browse/FHIR-27930)

--- a/input/pages/changes.md
+++ b/input/pages/changes.md
@@ -31,6 +31,7 @@ This page details changes made in each version of the Quality Measure IG
 * **Applied**: Clarified definition wording for usage element of Publishable Measure CQFM  ([FHIR-40241](https://jira.hl7.org/browse/FHIR-40241))
 * **Applied**: Updated Quality Programs code system, value set and Structured Definition, cardinality of program slice to 0..1, binding to 'example', updated guidance.  ([FHIR-40562](https://jira.hl7.org/browse/FHIR-40562))
 * **Applied**: Removed measure allocation extension and all references to it throughout  ([FHIR-40590](https://jira.hl7.org/browse/FHIR-40590))
+* **Applied**: Added PI Measure example (no library) [FHIR-27930](https://jira.hl7.org/browse/FHIR-27930)
 
 
 ### STU3 Release for FHIR R4 (v3.0.0)

--- a/input/pages/examples.md
+++ b/input/pages/examples.md
@@ -8,6 +8,7 @@
 * [**RatioMeasure**](Measure-EXMRatio-FHIR.html) Ratio measure example - [Library](Library-EXMRatio-FHIR.html)
 * [**Terminology**](Measure-Terminology-FHIR.html) Example illustrating terminology usage - [Library](Library-Terminology-FHIR.html)
 * [**RiskAdjustment**](Measure-measure-risk-adjustment-FHIR2.html) Example illustrating risk adjustment usage - [Library](Library-risk-adjustment-FHIR2.html)
+* [**PromotingInteroperabilityMeasure**](Measure-measure-pi-exm.html) Promoting Interoperability measure example <!---  [Library](Library-EXMRatio.html) -->
 * [**Common Library**](Library-Common.html) Usage example illustrating a library to share logic between measures
 * [**SupplementalDataElements**](Library-SupplementalDataElements.html) Library illustrating common supplemental data elements
 

--- a/input/resources/measure-pi-exm.xml
+++ b/input/resources/measure-pi-exm.xml
@@ -1,0 +1,260 @@
+<Measure xmlns="http://hl7.org/fhir">
+   <id value="measure-pi-exm"></id>
+   <meta>
+      <profile value="http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/proportion-measure-cqfm"></profile>
+      <profile value="http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/computable-measure-cqfm"></profile>
+   </meta>
+<!--   
+   <contained>
+      <Library xmlns="http://hl7.org/fhir">
+         <id value="effective-data-requirements"></id>
+         <extension url="http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition">
+            <extension url="libraryName">
+               <valueString value="EXMRatio"></valueString>
+            </extension>
+            <extension url="name">
+               <valueString value="Qualifying Encounters"></valueString>
+            </extension>
+            <extension url="statement">
+               <valueString value="define &quot;Qualifying Encounters&quot;:
+  [&quot;Encounter&quot;: &quot;Inpatient&quot;]"></valueString>
+            </extension>
+            <extension url="displaySequence">
+               <valueInteger value="0"></valueInteger>
+            </extension>
+         </extension>
+         <extension url="http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition">
+            <extension url="libraryName">
+               <valueString value="EXMRatio"></valueString>
+            </extension>
+            <extension url="name">
+               <valueString value="Initial Population"></valueString>
+            </extension>
+            <extension url="statement">
+               <valueString value="define &quot;Initial Population&quot;:
+  &quot;Qualifying Encounters&quot;"></valueString>
+            </extension>
+            <extension url="displaySequence">
+               <valueInteger value="1"></valueInteger>
+            </extension>
+         </extension>
+         <extension url="http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition">
+            <extension url="libraryName">
+               <valueString value="EXMRatio"></valueString>
+            </extension>
+            <extension url="name">
+               <valueString value="Numerator"></valueString>
+            </extension>
+            <extension url="statement">
+               <valueString value="define &quot;Numerator&quot;:
+  &quot;Initial Population&quot;"></valueString>
+            </extension>
+            <extension url="displaySequence">
+               <valueInteger value="2"></valueInteger>
+            </extension>
+         </extension>
+         <extension url="http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition">
+            <extension url="libraryName">
+               <valueString value="EXMRatio"></valueString>
+            </extension>
+            <extension url="name">
+               <valueString value="Denominator"></valueString>
+            </extension>
+            <extension url="statement">
+               <valueString value="define &quot;Denominator&quot;:
+  &quot;Initial Population&quot;"></valueString>
+            </extension>
+            <extension url="displaySequence">
+               <valueInteger value="3"></valueInteger>
+            </extension>
+         </extension>
+         <name value="EffectiveDataRequirements"/>
+         <status value="active"></status>
+         <type>
+            <coding>
+               <system value="http://terminology.hl7.org/CodeSystem/library-type"></system>
+               <code value="module-definition"></code>
+            </coding>
+         </type>
+         <date value="2022-02-22T10:37:04-07:00"></date>
+         <relatedArtifact>
+            <type value="depends-on"></type>
+            <display value="Value set Inpatient"></display>
+            <resource value="http://example.org/fhir/ValueSet/inpatient"></resource>
+         </relatedArtifact>
+         <parameter>
+            <name value="Numerator"></name>
+            <use value="out"></use>
+            <min value="0"></min>
+            <max value="*"></max>
+            <type value="Encounter"></type>
+         </parameter>
+         <parameter>
+            <name value="Denominator"></name>
+            <use value="out"></use>
+            <min value="0"></min>
+            <max value="*"></max>
+            <type value="Encounter"></type>
+         </parameter>
+         <parameter>
+            <name value="Initial Population"></name>
+            <use value="out"></use>
+            <min value="0"></min>
+            <max value="*"></max>
+            <type value="Encounter"></type>
+         </parameter>
+         <dataRequirement>
+            <type value="Encounter"></type>
+            <profile value="http://hl7.org/fhir/StructureDefinition/Encounter"></profile>
+            <mustSupport value="type"></mustSupport>
+            <codeFilter>
+               <path value="type"></path>
+               <valueSet value="http://example.org/fhir/ValueSet/inpatient"></valueSet>
+            </codeFilter>
+         </dataRequirement>
+      </Library>
+   </contained> -->
+   <!--
+   <extension url="http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis">
+      <valueCode value="Encounter"></valueCode>
+   </extension>
+   <extension url="http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoringUnit">
+      <valueCodeableConcept>
+         <coding>
+            <system value="http://unitsofmeasure.org"></system>
+            <code value="/1000.d"></code>
+         </coding>
+      </valueCodeableConcept>
+   </extension> -->
+   <extension url="http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-softwaresystem">
+      <valueReference>
+         <reference value="Device/software-system-example"></reference>
+      </valueReference>
+   </extension>
+   <extension id="effective-data-requirements" url="http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-effectiveDataRequirements">
+      <valueReference>
+         <reference value="#effective-data-requirements"></reference>
+      </valueReference>
+   </extension>
+   <url value="http://example.org/fhir/measures/measure-proportion-exm"></url>
+   <identifier>
+      <system value="http://example.org/fhir/cqi/ecqm/Measure/Identifier/exm"></system>
+      <value value="EXMPI"></value>
+   </identifier>
+   <version value="1.0.0"></version>
+   <name value="EXMPromotingInteroperabilityMeasure"></name>
+   <title value="EXM Promoting Interoperability Measure"></title>
+   <status value="active"></status>
+   <experimental value="true"></experimental>
+   <date value="2023-05-31"></date>
+   <publisher value="Example Measure Publisher"></publisher>
+   <contact>
+      <telecom>
+         <system value="url"></system>
+         <value value="http://www.examplePublisher.org/"></value>
+      </telecom>
+   </contact>
+   <description value="An example FHIR-based publishable measure - Promoting Interoperability"></description>
+   <useContext>
+      <code>
+         <system value="http://terminology.hl7.org/CodeSystem/usage-context-type"></system>
+         <code value="program"></code>
+      </code>
+      <valueCodeableConcept>
+         <coding>
+            <system value="http://hl7.org/fhir/us/cqfmeasures/CodeSystem/quality-programs"></system>
+            <code value="ep-ec"></code>
+         </coding>
+         <text value="eligible-provider"></text>
+      </valueCodeableConcept>
+   </useContext>
+   <jurisdiction>
+      <coding>
+         <system value="urn:iso:std:iso:3166"></system>
+         <code value="US"></code>
+      </coding>
+   </jurisdiction>
+   <purpose value="The purpose of this measure is to..."></purpose>
+   <usage value="Users of this measure should be aware of..."></usage>
+   <copyright value="Example Copyright Statement"></copyright>
+   <approvalDate value="2019-02-17"></approvalDate>
+   <lastReviewDate value="2019-02-17"></lastReviewDate>
+   <effectivePeriod>
+      <extension url="http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-effectivePeriodAnchor">
+         <valueDateTime value="2018-01-01"></valueDateTime>
+      </extension>
+      <extension url="http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-effectivePeriodDuration">
+         <valueDuration>
+            <value value="1"></value>
+            <system value="http://unitsofmeasure.org"></system>
+            <code value="a"></code>
+         </valueDuration>
+      </extension>
+      <start value="2018-01-01"></start>
+      <end value="2018-12-31"></end>
+   </effectivePeriod>
+   <topic>
+      <coding>
+         <system value="http://loinc.org"></system>
+         <code value="57024-2"></code>
+      </coding>
+      <text value="Health Quality Measure Document"></text>
+   </topic>
+   <author>
+      <name value="Example Measure Content Developer"></name>
+   </author>
+   <disclaimer value="Example disclaimer"></disclaimer>
+   <scoring>
+      <coding>
+         <system value="http://terminology.hl7.org/CodeSystem/measure-scoring"></system>
+         <code value="proportion"></code>
+         <display value="proportion"></display>
+      </coding>
+   </scoring>
+<!--   
+   <type>
+      <coding>
+         <system value="http://terminology.hl7.org/CodeSystem/measure-type"></system>
+         <code value="process"></code>
+      </coding>
+   </type>
+   <improvementNotation>
+      <coding>
+         <system value="http://terminology.hl7.org/CodeSystem/measure-improvement-notation"></system>
+         <code value="decrease"></code>
+         <display value="Decreased score indicates improvement"></display>
+      </coding>
+   </improvementNotation>
+-->
+   <group id="group-1">
+      <population id="numerator">
+         <code>
+            <coding>
+               <system value="http://terminology.hl7.org/CodeSystem/measure-population"></system>
+               <code value="numerator"></code>
+               <display value="Numerator"></display>
+            </coding>
+         </code>
+         <description value="The number of prescriptions in the denominator generated and transmitted electronically using CEHRT."></description>         
+         <criteria>
+            <language value="text/cql-identifier"></language>
+            <expression value="Numerator"></expression>
+         </criteria>
+      </population>
+      <population id="denominator">
+         <code>
+            <coding>
+               <system value="http://terminology.hl7.org/CodeSystem/measure-population"></system>
+               <code value="denominator"></code>
+               <display value="Denominator"></display>
+            </coding>
+         </code>
+         <description value="Number of prescriptions written for drugs requiring a prescription in order to be dispensed other than controlled substances during the performance period; or number of
+prescriptions written for drugs requiring a prescription in order to be dispensed during the performance period."></description>         
+         <criteria>
+            <language value="text/cql-identifier"></language>
+            <expression value="Denominator"></expression>
+         </criteria>
+      </population>
+   </group>
+</Measure>

--- a/pages/changes.md
+++ b/pages/changes.md
@@ -13,6 +13,7 @@ title: Changes
 * [FHIR-25285](https://jira.hl7.org/browse/FHIR-25285) - Changed definition term extension to preserve association of term and definition
 * [FHIR-21998](https://jira.hl7.org/browse/FHIR-21998) - Disallowed stratification of ratio measures
 * [FHIR-21996](https://jira.hl7.org/browse/FHIR-21996) - Required use of `called` clause for included libraries
+* [FHIR-27930](https://jira.hl7.org/browse/FHIR-27930) -  Added PI Measure example (no library) 
 
 #### Compatible, Substantive
 * Corrections to proportion, ratio, and continuous-variable measure profiles


### PR DESCRIPTION
Added PI Measure to examples page.
Note: This measure has no associated CQL library, so there should be no "Library" link next to the measure line item on the examples page. Further, once drilling down on that library, there should be no "Download CQL" line item on the Narrative content tab.  