### PR TITLE
artifactComment context type fhirpath for elements

### DIFF
--- a/input/profiles/StructureDefinition-cqfm-artifactComment.json
+++ b/input/profiles/StructureDefinition-cqfm-artifactComment.json
@@ -48,6 +48,14 @@
     {
       "type": "element",
       "expression": "Library"
+    },
+    {
+      "expression": "Measure.descendants().ofType(Element)",
+      "type": "fhirpath"
+    },
+    {
+      "expression": "Library.descendants().ofType(Element)",
+      "type": "fhirpath"
     }
   ],
   "type": "Extension",


### PR DESCRIPTION
We intended to allow artifactComment on any element within Measure or Library. Current context does not allow that.