### PR TITLE
FHIR-43358 appliesTo short s/group/population

### DIFF
--- a/input/profiles/StructureDefinition-computable-measure-cqfm.json
+++ b/input/profiles/StructureDefinition-computable-measure-cqfm.json
@@ -658,7 +658,7 @@
         "id" : "Measure.group.stratifier.extension:appliesTo",
         "path" : "Measure.group.stratifier.extension",
         "sliceName" : "appliesTo",
-        "short" : "Which group should this stratification apply to? If none is specified, the stratification applies to all populations in the group.",
+        "short" : "Which population should this stratification apply to? If none is specified, the stratification applies to all populations in the group.",
         "min" : 0,
         "max" : "*",
         "type" : [


### PR DESCRIPTION
https://jira.hl7.org/browse/FHIR-43358 

Replace "group" with "population" in https://github.com/HL7/cqf-measures/blob/master/input/profiles/StructureDefinition-computable-measure-cqfm.json for Measure.group.stratifier.extension:appliesTo.

Before: Which **group** should this stratification apply to?

After: Which **population** should this stratification apply to?
