### PR TITLE
Edits and link fixes to index.md and using-cql.md pages

### DIFF
--- a/input/data/package-list.yml
+++ b/input/data/package-list.yml
@@ -35,6 +35,8 @@ list:
       1. **Applied**: Correct invalid json in StructureDefinition-cqfm-fhirQueryPattern.json ([FHIR-43086](https://jira.hl7.org/browse/FHIR-43086))([Applied here](StructureDefinition-cqfm-fhirQueryPattern.html))
       1. **Applied**: Allow multiple quality programs and bind value set as example ([FHIR-43320](https://jira.hl7.org/browse/FHIR-43320))([Applied here](StructureDefinition-publishable-library-cqfm.html)) and ([here](StructureDefinition-publishable-measure-cqfm.html))
       1. **Applied**: Correct short description about appliesTo extension ([FHIR-43358](https://jira.hl7.org/browse/FHIR-43358))([Applied here](StructureDefinition-computable-measure-cqfm.html))
+      1. **Applied**: Minor edits to list items in 'How to read this guide' ([FHIR-44118](https://jira.hl7.org/browse/FHIR-44118))([Applied here](index.html))
+      1. **Applied**: Corrected broken links ([FHIR-43620](https://jira.hl7.org/browse/FHIR-43620))([Applied here](index.html)), and ([here](using-cql.html))
 
 
       

--- a/input/pages/changes.md
+++ b/input/pages/changes.md
@@ -32,6 +32,8 @@ This page details changes made in each version of the Quality Measure IG
 * **Applied**: Updated the Quality Improvement Ecosystem paragraph to increase readability ([FHIR-44070](https://jira.hl7.org/browse/FHIR-44070))([Applied here](https://hl7.org/fhir/us/cqfmeasures/2024Jan/#quality-improvement-ecosystem))
 * **Applied**: Updated the text and image in data model standard landscape section to remove DEQM and HEDIS and replaced with Measure Content IG ([FHIR-44530](https://jira.hl7.org/browse/FHIR-44530))([Applied here](https://hl7.org/fhir/us/cqfmeasures/2024Jan/#data-model-standards-landscape))
 * **Applied**: Created an improvementNotationGuidance extension in the FHIR extensions pack and added to Publishable Measure at root and group level. ([FHIR-43463](https://jira.hl7.org/browse/FHIR-43463))([Applied here](https://hl7.org/fhir/us/cqfmeasures/StructureDefinition-publishable-measure-cqfm.html))
+* **Applied**: Minor edits to list items in 'How to read this guide' ([FHIR-44118](https://jira.hl7.org/browse/FHIR-44118))([Applied here](index.html))
+* **Applied**: Corrected broken links ([FHIR-43620](https://jira.hl7.org/browse/FHIR-43620))([Applied here](index.html)), and ([here](using-cql.html))
 
 ### STU4 Publication for FHIR R4 (v4.0.0)
 

--- a/input/pages/index.md
+++ b/input/pages/index.md
@@ -54,23 +54,23 @@ Refer to the [QI-Core implementation guide](http://hl7.org/fhir/us/qicore) for e
 This Guide is divided into several pages which are listed at the top of each
 page in the menu bar:
 
--  **[Home](index.html)**: The home page provides the summary and background information for the FHIR Quality Measure Implementation Guide
--  **[Introduction](introduction.html)**: The introduction provides a more detailed overview of quality measurement and the background for this guide
--  **[QMs](measure-conformance.html)**: This page describes measure representation and conformance requirements for QMs
--  **[Using CQL](using-cql.html)**: This page covers using Clinical Quality Language to author QMs
--  **[Composites](composite-measures.html)**: This page covers composite measure representation and conformance requirements
--  **[Packaging](packaging.html)**: This page describes measure packaging and distribution requirements for QMs
+-  **[Home](index.html)**: The home page provides the summary and background information for the FHIR Quality Measure Implementation Guide.
+-  **[Introduction](introduction.html)**: The introduction provides a more detailed overview of quality measurement and the background for this guide.
+-  **[QMs](measure-conformance.html)**: This page describes measure representation and conformance requirements for QMs.
+-  **[Using CQL](using-cql.html)**: This page covers using Clinical Quality Language to author QMs.
+-  **[Composites](composite-measures.html)**: This page covers composite measure representation and conformance requirements.
+-  **[Packaging](packaging.html)**: This page describes measure packaging and distribution requirements for QMs.
 Measures IG
--  **[Profiles](profiles.html)**: This page lists the set of profiles defined for use by QMs
--  **[Extensions](extensions.html)**: This page lists the set of extensions defined for use by QMs
--  **[Terminology](terminology.html)**: This page lists value sets and code systems defined in this IG
--  **[Capabilities](capabilities.html)**: This page defines the workflows and roles for QMs and contains the capability statements
+-  **[Profiles](profiles.html)**: This page lists the set of profiles defined for use by QMs.
+-  **[Extensions](extensions.html)**: This page lists the set of extensions defined for use by QMs.
+-  **[Terminology](terminology.html)**: This page lists value sets and code systems defined in this IG.
+-  **[Capabilities](capabilities.html)**: This page defines the workflows and roles for QMs and contains the capability statements.
 <div class="new-content" markdown="1">
 
--  **[Operations](operations.html)**: This page defines services and operations in support of authoring, publishing, and distributing QMs
+-  **[Operations](operations.html)**: This page defines services and operations in support of authoring, publishing, and distributing QMs.
 </div>
 
--  **[Examples](examples.html)**: This page provides examples used in the other pages, as well as by the Data Exchange for Quality
+-  **[Examples](examples.html)**: This page provides examples used in the other pages, as well as by the Data Exchange for Quality.
 -  **[Glossary](glossary.html)** This page defines terms related to quality measurement.
 -  **[Downloads](downloads.html)**: This page provides links to downloadable artifacts for implementations.
 -  **[Acknowledgements](acknowledgements.html)**
@@ -92,7 +92,7 @@ Measures IG
 
 Centers for Medicare &amp; Medicaid. Clinical Quality Measures Basics. [Online]. Available from: [https://www.cms.gov/Regulations-and-Guidance/Legislation/EHRIncentivePrograms/ClinicalQualityMeasures.html](https://www.cms.gov/Regulations-and-Guidance/Legislation/EHRIncentivePrograms/ClinicalQualityMeasures.html) [Accessed 11 October 2019].
 
-Centers for disease control and prevention. Adapting Clinical Guidelines for the Digital Age. [Online]. Available from: [https://www.cdc.gov/ddphss/clinical-guidelines/index.html](https://www.cdc.gov/ddphss/clinical-guidelines/index.html) [Accessed 11 October 2019].
+Centers for disease control and prevention. Adapting Clinical Guidelines for the Digital Age. [Online]. Available from:  [https://www.cdc.gov/csels/phio/clinical-guidelines/index.html](https://www.cdc.gov/csels/phio/clinical-guidelines/index.html) [Accessed 11 October 2019].
 
 Health level seven. Clinical Quality Framework - HL7 Clinical Quality Information Work Group Confluence Page. [Online]. Available from: [https://confluence.hl7.org/display/CQIWC/Clinical Quality Framework](https://confluence.hl7.org/display/CQIWC/Clinical%20Quality%20Framework) [Accessed 11 October 2019].
 

--- a/input/pages/using-cql.md
+++ b/input/pages/using-cql.md
@@ -482,7 +482,7 @@ define "Antithrombotic Not Administered":
 In this example for negation rationale, the logic looks for a member of the value set "Medical Reason" as the rationale
 for not administering any of the anticoagulant and antiplatelet medications specified in the "Antithrombotic Therapy"
 value set. To report Antithrombotic Therapy Not Administered, this is done by referencing the URI of the "Antithrombotic
-Therapy" value set using the [value set extension](http://hl7.org/fhir/extension-valueset-reference.html) to indicate
+Therapy" value set using the [value set extension](https://www.hl7.org/fhir/R4/extension-valueset-reference.html)  to indicate
 providers did not administer any of the medications in the "Antithrombotic Therapy" value set. By referencing the value
 set URI to negate the entire value set rather than reporting a specific member code from the value set, clinicians are
 not forced to having to arbitrarily select a specific medication from the "Antithrombotic Therapy" value set that they


### PR DESCRIPTION
index.md
	https://jira.hl7.org/browse/FHIR-43620 
                 - Section 1.4 References: corrected link for Adapting Clinical Guidelines for the Digital Age
	         - Section 1.6 Dependencies: next to ‘Using CQL with FHIR’ under heading ‘Package’: 
	                        Broken link hl7.fhr.uv.cql#1.0.0-ballot (Not found in current .md page)
	https://jira.hl7.org/browse/FHIR-44118 - added periods to sentences in 'How to read this guide' list"
	https://jira.hl7.org/browse/FHIR-44119 - Incorrect spelling of Practitioner seems to corrected already.

using-cql.md
	https://jira.hl7.org/browse/FHIR-43620:
		- Broken link: 4.1.3 Library Namespaces:  https://ecqi.healthit.gov/ecqm/measures 
		       (As this is a namespace example only, not neccessarily a link, no change needed.)
		- Corrected link for Antithrombotic Therapy value set.
