### PR TITLE
FHIR-43790 Use QI-core profile reference instead of base

### DIFF
--- a/input/data/package-list.yml
+++ b/input/data/package-list.yml
@@ -47,4 +47,5 @@ list:
       1. **Applied**: Updated QI-core version reference from STU5 to STU6 ([FHIR-43771](https://jira.hl7.org/browse/FHIR-43771))([Applied here](introduction.html))
       1. **Applied**: Updated CQL-base HQMF IF R1 version reference from STU4 to STU4.1 ([FHIR-43637](https://jira.hl7.org/browse/FHIR-43637))([Applied here](introduction.html))
       1. **Applied**: Updated paragraph in Scope section regarding Member Attribution (ATR) Lists  ([FHIR-43636](https://jira.hl7.org/browse/FHIR-43636))([Applied here](introduction.html))
+      1. **Applied**: Use QI-Core patient profile url in measure-EXMLogic-FHIR example rather than base patient profile reference.  ([FHIR-43790](https://jira.hl7.org/browse/FHIR-43790))([Applied here](Measure-EXMLogic-FHIR.json.html))
 

--- a/input/pages/changes.md
+++ b/input/pages/changes.md
@@ -44,6 +44,7 @@ This page details changes made in each version of the Quality Measure IG
 * **Applied**: Updated paragraph in Scope section regarding Member Attribution (ATR) Lists  ([FHIR-43636](https://jira.hl7.org/browse/FHIR-43636))([Applied here](introduction.html))
 * **Applied**: Updated tables in composite measure page for clarity ([FHIR-43714](https://jira.hl7.org/browse/FHIR-43714))([Applied here](composite-measures.html#all-or-nothing-scoring) and subsequent sections))
 * **Applied**: Added table to composite measure page for describing linear scoring vs. opportunity scoring ([FHIR-43715](https://jira.hl7.org/browse/FHIR-43715)) ([Applied here](composite-measures.html#subject-level-linear-combination-scoring))
+* **Applied**: Use QI-Core patient profile url in measure-EXMLogic-FHIR example rather than base patient profile reference.  ([FHIR-43790](https://jira.hl7.org/browse/FHIR-43790))([Applied here](Measure-EXMLogic-FHIR.json.html))
 
 ### STU4 Publication for FHIR R4 (v4.0.0)
 

--- a/input/resources/measure-exmlogic-FHIR.json
+++ b/input/resources/measure-exmlogic-FHIR.json
@@ -346,7 +346,7 @@
           ],
           "type" : "Patient",
           "profile" : [
-            "http://hl7.org/fhir/StructureDefinition/Patient"
+            "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient"
           ]
         },
         {
@@ -375,7 +375,7 @@
           ],
           "type" : "Patient",
           "profile" : [
-            "http://hl7.org/fhir/StructureDefinition/Patient"
+            "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient"
           ],
           "mustSupport" : [
             "url",
@@ -392,7 +392,7 @@
           ],
           "type" : "Patient",
           "profile" : [
-            "http://hl7.org/fhir/StructureDefinition/Patient"
+            "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient"
           ],
           "mustSupport" : [
             "url",


### PR DESCRIPTION
https://jira.hl7.org/browse/FHIR-43790

For the cqf-measures IG only,  measure-exmlogic-FHIR example:  per the comment in the resolution: "In addition, update the example to reference the QICore profile, rather than base patient, so that the path is resolvable on the profile",  changed reference for 'patient' to use the QICore profile.  (3 occurrences.)