### PR TITLE
FHIR-45888 Consider updating the CQFCommon dependency

### DIFF
--- a/input/cqfmeasures.xml
+++ b/input/cqfmeasures.xml
@@ -28,12 +28,6 @@
   <packageId value="hl7.fhir.us.cqfmeasures"/>
   <license value="CC0-1.0"/>
   <fhirVersion value="4.0.1"/>
-  <!-- Note this dependency is only included to support references to the FHIR-ModelInfo and FHIRCommon libraries used by examples in this IG -->
-  <dependsOn id="cqf">
-    <uri value="http://fhir.org/guides/cqf/common/ImplementationGuide/fhir.cqf.common"/>
-    <packageId value="fhir.cqf.common"/>
-    <version value="4.0.1"/>
-  </dependsOn>
   <!-- Note this dependency is only included to support references to the extensions used by example content in this IG -->
   <!--dependsOn id="qicore">
     <uri value="http://hl7.org/fhir/us/qicore/ImplementationGuide/hl7.fhir.us.qicore"/>


### PR DESCRIPTION
https://jira.hl7.org/browse/FHIR-45888

Removed dependson for cqf-common from cqfmeasures.xml
![Screenshot 2024-08-20 at 9 36 53 AM](https://github.com/user-attachments/assets/f563c255-e44b-4bdf-a091-ed3745926cbb)
