### PR TITLE
FHIR-45922 updated liquid templates,  additional QA

### DIFF
--- a/input/profiles/StructureDefinition-computable-measure-cqfm.json
+++ b/input/profiles/StructureDefinition-computable-measure-cqfm.json
@@ -85,7 +85,7 @@
             "key" : "cmp-4",
             "severity" : "error",
             "human" : "Improvement notation must be specified for scoring types other than cohort",
-			"expression" : "(scoring.exists() and scoring.coding.code in ('proportion' | 'ratio' | 'continuous-variable') and improvementNotation.exists()) xor (group.where(extension('http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoring').where(exists() and value.coding.code in ('proportion' | 'ratio' | 'continuous-variable')).exists() and extension('http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-improvementNotation').exists()).exists())"
+			"expression" : "(scoring.exists() and (scoring.coding.code.contains('proportion') or scoring.coding.code.contains('ratio') or scoring.coding.code.contains('continuous-variable') or scoring.coding.code.contains('composite')) and improvementNotation.exists()) xor (group.extension('http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoring').exists() and  (group.extension('http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoring').value.coding.code.contains('proportion') or   group.extension('http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoring').value.coding.code.contains('ratio') or   group.extension('http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoring').value.coding.code.contains('continuous-variable') or   group.extension('http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoring').value.coding.code.contains('composite')) and  group.extension('http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-improvementNotation').exists())"
           },
           {
             "key" : "cmp-5",

--- a/input/resources/Measure-BCSComponent.xml
+++ b/input/resources/Measure-BCSComponent.xml
@@ -1,7 +1,7 @@
 <Measure xmlns="http://hl7.org/fhir">
    <id value="BCSComponent"></id>
    <meta>
-      <profile value="http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareable-measure"></profile>
+      <profile value="http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablemeasure"></profile>
       <profile value="http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/computable-measure-cqfm"></profile>
       <profile value="http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/proportion-measure-cqfm"></profile>
       <profile value="http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/publishable-measure-cqfm"></profile>

--- a/input/resources/Measure-CCSComponent.xml
+++ b/input/resources/Measure-CCSComponent.xml
@@ -1,7 +1,7 @@
 <Measure xmlns="http://hl7.org/fhir">
    <id value="CCSComponent"></id>
    <meta>
-      <profile value="http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareable-measure"></profile>
+      <profile value="http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablemeasure"></profile>
       <profile value="http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/computable-measure-cqfm"></profile>
       <profile value="http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/proportion-measure-cqfm"></profile>
       <profile value="http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/publishable-measure-cqfm"></profile>

--- a/input/resources/measure-exm55-FHIR.json
+++ b/input/resources/measure-exm55-FHIR.json
@@ -5,8 +5,8 @@
     "profile": [ 
       "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cv-measure-cqfm", 
       "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/computable-measure-cqfm",
-      "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareable-measure",
-      "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cql-measure"
+      "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablemeasure",
+      "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cql-measure-cqfm"
     ]
   },
   "extension": [ {

--- a/templates/liquid/Library.liquid
+++ b/templates/liquid/Library.liquid
@@ -263,13 +263,6 @@
         </tr>
         {% endif %}
 
-        {% if Library.lastReviewDate.exists() %}
-        <tr>
-            <th scope="row"><b>Last Review Date: </b></th>
-            <td style="padding-left: 4px;">{{Library.lastReviewDate}}</td>
-        </tr>
-        {% endif %}
-
         {% if Library.effectivePeriod.exists() %}
         <tr>
             <th scope="row"><b>Effective Period: </b></th>

--- a/templates/liquid/Measure.liquid
+++ b/templates/liquid/Measure.liquid
@@ -64,8 +64,7 @@
         {% if Measure.effectivePeriod.exists() %}
             <tr>
                 <th scope="row"><b>Effective Period: </b></th>
-                <td style="padding-left: 4px;">{{Measure.effectivePeriod.start}}
-                    ..{{Measure.effectivePeriod.end}}</td>
+                <td style="padding-left: 4px;">{{Measure.effectivePeriod.start}}..{{Measure.effectivePeriod.end}}</td>
             </tr>
         {% endif %}
 
@@ -80,13 +79,6 @@
             <tr>
                 <th scope="row"><b>Experimental: </b></th>
                 <td style="padding-left: 4px;">{{Measure.experimental.value}}</td>
-            </tr>
-        {% endif %}
-
-        {% if Measure.date.exists() %}
-            <tr>
-                <th scope="row"><b>Date: </b></th>
-                <td style="padding-left: 4px;">{{Measure.date}}</td>
             </tr>
         {% endif %}
 
@@ -363,22 +355,29 @@
                                 {% for population in group.population %}
                                     <tr>
                                         <td>{{population.code.coding[0].display}}:</td>
-                                        {% if population.description.exists() %}
-                                            <td>{{population.description}}</td>
-                                        {% else %}
+
+                                        {% if population.criteria.expression.exists().not() %}
                                             <td>None</td>
+                                        {% else %}
+                                            {% if population.description.exists() %}
+                                                <td>{{population.description}}</td>
+                                            {% else %}
+                                                <td>None</td>
+                                            {% endif %}
                                         {% endif %}
+
                                     </tr>
                                 {% endfor %}
                                 {% if group.stratifier.exists() %}
                                   <tr><b>Stratifier Criteria: </b></tr>
                                     {% for stratifier in group.stratifier %}
                                         <tr>
-                                            <td>{{stratifier.code.coding[0].display}}:</td>
-                                            {% if stratifier.description.exists() %}
-                                                <td>{{stratifier.description}}</td>
+                                            {% if stratifier.code.coding[0].display.exists() %}
+                                                <td>{{stratifier.code.coding[0].display}}:</td>
+                                            {% else if stratifier.code.coding[0].code.exists() %}
+                                                <td>{{stratifier.code.coding[0].code}}:</td>
                                             {% else %}
-                                                <td>None</td>
+                                                <td>Stratum:</td>
                                             {% endif %}
                                         </tr>
                                     {% endfor %}
@@ -485,7 +484,7 @@
                         <p><b>Dependencies</b></p>
                         <ul>
                             {% for artifact in Measure.relatedArtifact.where(type = 'depends-on') %}
-                                <li>{{artifact.resource}}</li>
+                                <li>{{artifact.display}}</li>
                             {% endfor %}
                         </ul>
                     {% endif %}
@@ -528,7 +527,7 @@
         {% if Measure.extension.where(url = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-effectiveDataRequirements').exists() %}
             {% for contained in Measure.contained.where(id = 'effective-data-requirements') %}
                 <tr>
-                    <th scope="row"><b>Related Artifact Dependencies: </b></th>
+                    <th scope="row"><b>Terminology and Other Dependencies: </b></th>
                     <td style="padding-left: 4px;">
                         {% for relatedArtifact in contained.relatedArtifact.where(type = 'depends-on') %}
                             <li>{{relatedArtifact.resource}}</li>
@@ -564,8 +563,8 @@
                     <td style="padding-left: 4px;">
                         <table class="grid-dict">
                             <tr>
-                                <th><b>Type</b></th>
-                                <th><b>Elements</b></th>
+                                <th><b>Resource Type</b></th>
+                                <th><b>Resource Elements</b></th>
                                 <th><b>Valueset Name</b></th>
                                 <th><b>Valueset</b></th>
                             </tr>
@@ -630,7 +629,7 @@
                             <tr>
                                 {% for group in Measure.group %}
                                 <td> {{group.id}} </td>
-                                <td>
+                                <td style="padding-left: 4px;" colspan="3">
                                     {% if group.extension.where(url = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoring').exists() %}
                                         <b>Group scoring:</b>
                                         {% for extension in group.extension.where(url = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoring') %}
@@ -685,19 +684,19 @@
                                         </tr>
                                     {% endif %}
 
-                                    {% if group.extension.where(url = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-measureType').exists() %}
+                                    {% if group.extension.where(url = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-type').exists() %}
                                         <tr>
-                                        {% for extension in group.extension.where(url = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-measureType') %}
+                                        {% for extension in group.extension.where(url = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-type') %}
                                             <th scope="row"><b>Type: </b></th>
                                             <td style="padding-left: 4px;">
-                                                {% if extension.coding.exists() %}
-                                                    {% for coding in extension.coding %}
+                                                {% if extension.value.coding.exists() %}
+                                                    {% for coding in extension.value.coding %}
                                                         <p style="margin-bottom: 5px;">
                                                             <span>{{iif(coding.display.exists(), coding.display, coding.code)}} {{iif(coding.system != 'http://terminology.hl7.org/CodeSystem/measure-type', '(' + coding.system + ')', '')}}</span>
                                                         </p>
                                                     {% endfor %}
                                                 {% endif %}
-                                                {% if extension.coding.exists().not() and extension.text.exists() %}
+                                                {% if extension.value.coding.exists().not() and extension.text.exists() %}
                                                     {{extension.text}}
                                                 {% endif %}
                                             </td>
@@ -724,19 +723,26 @@
                                             <th scope="row"><b>Improvement Notation: </b></th>
                                             <td style="padding-left: 4px;">
                                             {% for extension in group.extension.where(url = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-improvementNotation') %}
-                                                {% if extension.coding.exists() %}
-                                                    {% for coding in extension.coding %}
+                                                {% if extension.value.coding.exists() %}
+                                                    {% for coding in extension.value.coding %}
                                                         <p style="margin-bottom: 5px;">
                                                             <span>{{iif(coding.display.exists(), coding.display, coding.code)}} {{iif(coding.system != 'http://terminology.hl7.org/CodeSystem/measure-improvement-notation', '(' + coding.system + ')', '')}}</span>
                                                         </p>
                                                     {% endfor %}
                                                 {% endif %}
-                                                {% if extension.coding.exists().not() and extension.text.exists() %}
+                                                {% if extension.value.coding.exists().not() and extension.text.exists() %}
                                                     {{extension.text}}
                                                 {% endif %}
                                             {% endfor %}
                                             </td>
                                         </tr>
+                                    {% endif %}
+
+                                    {% if group.extension.where(url = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-appliesTo').exists() %}
+                                    <tr>
+                                        <th scope="row"><b>Applies To: </b></th>
+                                        <td style="padding-left: 4px;">{{group.extension.where(url = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-appliesTo').value}}</td>
+                                    </tr>
                                     {% endif %}
 
                                 </td>


### PR DESCRIPTION
Updated the liquid templates (from https://github.com/cqframework/sample-content-ig/releases/tag/v0.4.3 )

Fixed some QA issues (reduced errors from 42 to 18). Biggest change was to update the constraint expression cmp-4 in StructureDefinition-computable-measure-cqfm.json to comprehend 0..* cardinality of scoring.coding.code.   New definition:  

(scoring.exists() and (scoring.coding.code.contains('proportion') or scoring.coding.code.contains('ratio') or scoring.coding.code.contains('continuous-variable') or scoring.coding.code.contains('composite')) and improvementNotation.exists()) xor 
(group.extension('http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoring').exists() and 
 group.extension('http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoring').value.coding.code.contains('proportion') or 
 group.extension('http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoring').value.coding.code.contains('ratio') or 
 group.extension('http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoring').value.coding.code.contains('continuous-variable') or 
 group.extension('http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoring').value.coding.code.contains('composite') and 
 group.extension('http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-improvementNotation').exists())

Attaching 6 QA screenshots (3 showing errors before, 3 showing errors after)...
![QA-after-1](https://github.com/user-attachments/assets/9c3bb055-8b30-4bd5-a935-00f5466167bf)
![QA-after-2](https://github.com/user-attachments/assets/e90cb9b3-e7c4-4847-8c0e-80ab04158ca0)
![QA-after-3](https://github.com/user-attachments/assets/fbd2d4bb-853d-4fc2-aaf9-eba19a93dfa7)
![QA-before-1](https://github.com/user-attachments/assets/884e1c74-1403-4ac9-8266-00cfab3dd0a7)
![QA-before-2](https://github.com/user-attachments/assets/ca57e44f-d2a2-4258-9058-a9be54a139de)
![QA-before-3](https://github.com/user-attachments/assets/452b0264-95c3-4a22-a2d8-bd86de3353e2)
