### PR TITLE
Terminology tests using wrong value set corrected

### DIFF
--- a/postman-tests/collections/cqf-measures-terminology-service-tests.postman_collection.json
+++ b/postman-tests/collections/cqf-measures-terminology-service-tests.postman_collection.json
@@ -4475,15 +4475,15 @@
                       "listen": "test",
                       "script": {
                         "exec": [
-                          "// Based on source of truth: SOT@ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1096.82|20170801 @SOT",
+                          "// Based on source of truth: SOT@ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.611|20200319 @SOT",
                           "pm.test(\"Response status code is 200\", function () {",
                           "    pm.expect(pm.response.code).to.equal(200);",
                           "});",
                           "",
-                          "pm.test(\"Version is 20170801\", function () {",
+                          "pm.test(\"Version is 20200319\", function () {",
                           "        const responseData = pm.response.json();",
                           "",
-                          "    pm.expect(responseData.entry[0].resource.version).equals(\"20170801\");",
+                          "    pm.expect(responseData.entry[0].resource.version).equals(\"20200319\");",
                           "    if (pm.environment.get(\"VALUESET_DEBUG\") === true){",
                           "       console.log(responseData);",
                           "    }",
@@ -4499,7 +4499,7 @@
                     "method": "GET",
                     "header": [],
                     "url": {
-                      "raw": "{{SERVER_URL}}ValueSet/?url=http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1096.82&version=20170801",
+                      "raw": "{{SERVER_URL}}ValueSet/?url=http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.611&version=20200319",
                       "host": [
                         "{{SERVER_URL}}ValueSet"
                       ],
@@ -4509,11 +4509,11 @@
                       "query": [
                         {
                           "key": "url",
-                          "value": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1096.82"
+                          "value": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.611"
                         },
                         {
                           "key": "version",
-                          "value": "20170801"
+                          "value": "20200319"
                         }
                       ]
                     }
@@ -4527,21 +4527,21 @@
                       "listen": "test",
                       "script": {
                         "exec": [
-                          "// Based on source of truth: SOT@ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1096.82|20170801 @SOT",
+                          "// Based on source of truth: SOT@ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.611|20200319 @SOT",
                           "pm.test(\"Response status code is 200\", function () {",
                           "    pm.expect(pm.response.code).to.equal(200);",
                           "});",
                           "",
-                          "pm.test(\"Name is InactiveInterventionsRelatedToMedicationManagementMedicationActionPlan\", function () {",
+                          "pm.test(\"Name is N3MirrorGoldmannExam\", function () {",
                           "        const responseData = pm.response.json();",
                           "",
-                          "    pm.expect(responseData.entry[0].resource.name).equals(\"InactiveInterventionsRelatedToMedicationManagementMedicationActionPlan\");",
+                          "    pm.expect(responseData.entry[0].resource.name).equals(\"N3MirrorGoldmannExam\");",
                           "});",
                           "",
-                          "pm.test(\"Publisher is PharmacyHIT\", function () {",
+                          "pm.test(\"Publisher is ASRS Quality Measure Development Steward\", function () {",
                           "        const responseData = pm.response.json();",
                           "",
-                          "    pm.expect(responseData.entry[0].resource.publisher).equals(\"PharmacyHIT\");",
+                          "    pm.expect(responseData.entry[0].resource.publisher).equals(\"ASRS Quality Measure Development Steward\");",
                           "    if (pm.environment.get(\"VALUESET_DEBUG\") === true){",
                           "       console.log(responseData);",
                           "    }",
@@ -4557,7 +4557,7 @@
                     "method": "GET",
                     "header": [],
                     "url": {
-                      "raw": "{{SERVER_URL}}ValueSet/?identifier=urn:oid:2.16.840.1.113762.1.4.1096.82",
+                      "raw": "{{SERVER_URL}}ValueSet/?identifier=urn:oid:2.16.840.1.113762.1.4.1047.611",
                       "host": [
                         "{{SERVER_URL}}ValueSet"
                       ],
@@ -4567,7 +4567,7 @@
                       "query": [
                         {
                           "key": "identifier",
-                          "value": "urn:oid:2.16.840.1.113762.1.4.1096.82"
+                          "value": "urn:oid:2.16.840.1.113762.1.4.1047.611"
                         }
                       ]
                     }
@@ -5122,7 +5122,7 @@
                   "script": {
                     "exec": [
                       "//SOT@## ValueSet 10 ValidateCode @SOT",
-                      "// Based on source of truth: SOT@ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1096.82|20200319 @SOT",
+                      "// Based on source of truth: SOT@ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.611|20200319 @SOT",
                       "pm.test(\"Response status code is 200\", function () {",
                       "    pm.expect(pm.response.code).to.equal(200);",
                       "});",
@@ -5192,7 +5192,7 @@
                   "listen": "test",
                   "script": {
                     "exec": [
-                      "// Based on source of truth: SOT@ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1096.82|20200319 @SOT",
+                      "// Based on source of truth: SOT@ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.611|20200319 @SOT",
                       "pm.test(\"Response status code is 200\", function () {",
                       "    pm.expect(pm.response.code).to.equal(200);",
                       "});",
@@ -5255,7 +5255,7 @@
                   "listen": "test",
                   "script": {
                     "exec": [
-                      "// Based on source of truth: SOT@ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1096.82|20200319 @SOT",
+                      "// Based on source of truth: SOT@ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.611|20200319 @SOT",
                       "pm.test(\"Response status code is 200\", function () {",
                       "    pm.expect(pm.response.code).to.equal(200);",
                       "});",
@@ -5324,7 +5324,7 @@
                   "listen": "test",
                   "script": {
                     "exec": [
-                      "// Based on source of truth: SOT@ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1096.82|20200319 @SOT",
+                      "// Based on source of truth: SOT@ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.611|20200319 @SOT",
                       "pm.test(\"Response status code is 200\", function () {",
                       "    pm.expect(pm.response.code).to.equal(200);",
                       "});",
@@ -5387,7 +5387,8 @@
                   "listen": "test",
                   "script": {
                     "exec": [
-                      "// Based on source of truth: SOT@ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1096.82|20200319 @SOT",
+                      "// Based on source of truth: SOT@ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.611|20200319 @SOT",
+                      "// VSAC currently returning 'Invalid request: The FHIR endpoint on this server does not know how to handle POST operation[ValueSet] with parameters [[valueset]]'",
                       "pm.test(\"Response status code is 200\", function () {",
                       "    pm.expect(pm.response.code).to.equal(200);",
                       "});",
@@ -5450,7 +5451,7 @@
                   "listen": "test",
                   "script": {
                     "exec": [
-                      "// Based on source of truth: SOT@ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1096.82|20200319 @SOT",
+                      "// Based on source of truth: SOT@ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.611|20200319 @SOT",
                       "pm.test(\"Response status code is 200\", function () {",
                       "    pm.expect(pm.response.code).to.equal(200);",
                       "});",
@@ -5469,7 +5470,12 @@
                       "    const parameterEntry = responseData.parameter.find(m => m.name === \"result\");",
                       "    pm.expect(parameterEntry.valueBoolean).to.be.true;",
                       "});",
-                      ""
+                      "",
+                      "pm.test(\"Parameters contain a display of Goldmann three-mirror contact lens (physical object)\", function () {",
+                      "    const responseData = pm.response.json();",
+                      "    const parameterEntry = responseData.parameter.find(m => m.name === \"display\");",
+                      "    pm.expect(parameterEntry.valueString).equals(\"Goldmann three-mirror contact lens (physical object)\");",
+                      "});"
                     ],
                     "type": "text/javascript",
                     "packages": {}

--- a/postman-tests/truthSources.md
+++ b/postman-tests/truthSources.md
@@ -1,4 +1,4 @@
-The following lists test sections and the required resources for those sections. This file was generated using sot.sh at 2024-07-23 12:38:36
+The following lists test sections and the required resources for those sections. This file was generated using sot.sh at 2024-09-18 07:58:01
 /
 ## CodeSystem 1 Shareable 
  https://hl7.org/fhir/R4/codesystem-request-intent.json 
@@ -53,8 +53,8 @@ The following lists test sections and the required resources for those sections.
 ## ValueSet 8 Search 
  http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.611 
  http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005 
- http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1096.82|20170801 
- http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1096.82|20170801 
+ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.611|20200319 
+ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.611|20200319 
  http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.611 
  http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.611 
  http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1213.11|20190917 
@@ -64,12 +64,12 @@ The following lists test sections and the required resources for those sections.
  http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005|20240105 
  http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005|20190315 
 ## ValueSet 10 ValidateCode 
- http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1096.82|20200319 
- http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1096.82|20200319 
- http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1096.82|20200319 
- http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1096.82|20200319 
- http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1096.82|20200319 
- http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1096.82|20200319 
+ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.611|20200319 
+ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.611|20200319 
+ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.611|20200319 
+ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.611|20200319 
+ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.611|20200319 
+ http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.611|20200319 
 ## ValueSet 11 GET 
  http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005|20240105 
  http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005|20190315 


### PR DESCRIPTION
Corrected wrong valueset by replacing 2.16.840.1.113762.1.4.1096.82 with 2.16.840.1.113762.1.4.1047.611, correcting tests and generating a new truthSources.md.